### PR TITLE
Day 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ hls.log
 cabal.project.local
 cabal.project.local~
 .ghc.environment.*
+inputs

--- a/src/Day1.hs
+++ b/src/Day1.hs
@@ -1,11 +1,59 @@
-module Day1 where
+module Day1 (part1, part2, parse, program) where
+
+import Data.Bifunctor (Bifunctor (second), bimap)
+import Data.List (sort)
+import qualified Data.Map as M
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
+import Data.Tuple (swap)
+import Data.Void (Void)
+import Text.Megaparsec (Parsec, optional, runParser)
+import Text.Megaparsec.Char (eol, space)
+import Text.Megaparsec.Char.Lexer (decimal)
+import Text.Megaparsec.Error (ParseErrorBundle)
+import Utils (groupMap)
 
 program :: FilePath -> IO ()
 program = (=<<) print . fmap logic . T.readFile
 
-data Answer = Answer deriving (Eq, Show)
+data Answer = Answer Int Int deriving (Eq, Show)
 
-logic :: T.Text -> Answer
-logic = const Answer
+answer :: [(Int, Int)] -> Answer
+answer = Answer <$> part1 <*> part2
+
+logic :: T.Text -> Either ParsingError Answer
+logic = fmap answer . parseAll
+
+part1 :: (Ord a, Num a) => [(a, a)] -> a
+part1 =
+  sum
+    . (zipWith distance <$> fst <*> snd)
+    . bimap sort sort
+    . unzip
+ where
+  distance = (abs .) . (-)
+
+part2 :: (Integral a) => [(a, a)] -> Int
+part2 =
+  sum
+    . uncurry similarities
+    . swap
+    . second occurrences
+    . unzip
+ where
+  similarities m = fmap (\b -> fromIntegral b * M.findWithDefault 0 b m)
+
+occurrences :: (Ord a) => [a] -> M.Map a Int
+occurrences = fmap length . groupMap id id
+
+type Parser = Parsec Void T.Text
+type ParsingError = ParseErrorBundle T.Text Void
+
+parser :: Parser (Int, Int)
+parser = (,) <$> (decimal <* space) <*> (decimal <* optional eol)
+
+parse :: T.Text -> Either ParsingError (Int, Int)
+parse = runParser parser "input file"
+
+parseAll :: T.Text -> Either ParsingError [(Int, Int)]
+parseAll = traverse parse . T.lines

--- a/src/Day1.hs
+++ b/src/Day1.hs
@@ -1,4 +1,4 @@
-module Day1 (part1, part2, parse, program) where
+module Day1 (logic, part1, part2, parse, program, Answer(..)) where
 
 import Data.Bifunctor (Bifunctor (second), bimap)
 import Data.List (sort)

--- a/src/Day1.hs
+++ b/src/Day1.hs
@@ -3,6 +3,7 @@ module Day1 (part1, part2, parse, program) where
 import Data.Bifunctor (Bifunctor (second), bimap)
 import Data.List (sort)
 import qualified Data.Map as M
+import Data.Semigroup (Sum (..))
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import Data.Tuple (swap)
@@ -11,7 +12,7 @@ import Text.Megaparsec (Parsec, optional, runParser)
 import Text.Megaparsec.Char (eol, space)
 import Text.Megaparsec.Char.Lexer (decimal)
 import Text.Megaparsec.Error (ParseErrorBundle)
-import Utils (groupMap)
+import Utils (groupBy)
 
 program :: FilePath -> IO ()
 program = (=<<) print . fmap logic . T.readFile
@@ -26,8 +27,9 @@ logic = fmap answer . parseAll
 
 part1 :: (Ord a, Num a) => [(a, a)] -> a
 part1 =
-  sum
-    . (zipWith distance <$> fst <*> snd)
+  getSum
+    . foldMap (Sum . uncurry distance)
+    . uncurry zip
     . bimap sort sort
     . unzip
  where
@@ -35,16 +37,16 @@ part1 =
 
 part2 :: (Integral a) => [(a, a)] -> Int
 part2 =
-  sum
+  getSum
     . uncurry similarities
     . swap
     . second occurrences
     . unzip
  where
-  similarities m = fmap (\b -> fromIntegral b * M.findWithDefault 0 b m)
+  similarities m = foldMap (\b -> Sum (fromIntegral b * M.findWithDefault 0 b m))
 
 occurrences :: (Ord a) => [a] -> M.Map a Int
-occurrences = fmap length . groupMap id id
+occurrences = fmap length . groupBy id
 
 type Parser = Parsec Void T.Text
 type ParsingError = ParseErrorBundle T.Text Void

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -1,0 +1,11 @@
+module Utils (groupBy, groupMap) where
+
+import Data.Foldable (toList)
+import qualified Data.Map as M
+import qualified Data.Sequence as Seq
+
+groupBy :: (Ord k) => (a -> k) -> [a] -> M.Map k [a]
+groupBy key = groupMap key id
+
+groupMap :: (Ord k) => (a -> k) -> (a -> v) -> [a] -> M.Map k [v]
+groupMap key value = M.map toList . M.fromListWith (flip (<>)) . fmap (\a -> (key a, Seq.singleton (value a)))

--- a/test/Day1Spec.hs
+++ b/test/Day1Spec.hs
@@ -1,21 +1,34 @@
+{-# LANGUAGE QuasiQuotes #-}
+
 module Day1Spec where
 
-import Day1
-import Test.Hspec
-import Test.Hspec.QuickCheck
-import Test.QuickCheck
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
+import Day1 (parse, part1, part2)
+import NeatInterpolation (trimming)
+import SpecUtils (shouldBePretty)
+import Test.Hspec (Expectation, Spec, describe, expectationFailure, it, shouldBe)
+import Test.Hspec.QuickCheck ()
+import Test.QuickCheck ()
+
+example :: T.Text
+example =
+  [trimming|
+      3   4
+      4   3
+      2   5
+      1   3
+      3   9
+      3   3
+      |]
 
 spec :: Spec
 spec = describe "Day 1" $ do
-  it ""
-    $ 1
-    `shouldBe` 1
+  it "parse line" $
+    parse "3 4" `shouldBePretty` Right (3, 4)
 
-  prop ""
-    $ \l -> reverse (reverse l) == (l :: [Int])
+  it "part 1" $
+    (fmap part1 . traverse parse . T.lines) example `shouldBePretty` Right 11
 
-  xit "solve the puzzle" $ do
-     input <- T.readFile "resources/input1"
-     logic input `shouldBe` Answer
+  it "part 2" $
+    (fmap part2 . traverse parse . T.lines) example `shouldBePretty` Right 31

--- a/test/Day1Spec.hs
+++ b/test/Day1Spec.hs
@@ -4,7 +4,7 @@ module Day1Spec where
 
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
-import Day1 (parse, part1, part2)
+import Day1 (Answer, Answer(..), logic, parse, part1, part2)
 import NeatInterpolation (trimming)
 import SpecUtils (shouldBePretty)
 import Test.Hspec (Expectation, Spec, describe, expectationFailure, it, shouldBe)
@@ -32,3 +32,6 @@ spec = describe "Day 1" $ do
 
   it "part 2" $
     (fmap part2 . traverse parse . T.lines) example `shouldBePretty` Right 31
+
+  it "both" $
+    logic example `shouldBePretty` Right (Answer 11 31)

--- a/test/SpecUtils.hs
+++ b/test/SpecUtils.hs
@@ -1,0 +1,35 @@
+module SpecUtils where
+
+import Test.Hspec ( describe, it, shouldBe, Spec , Expectation, expectationFailure)
+import Text.Megaparsec (ParseErrorBundle, errorBundlePretty, Stream, ShowErrorComponent, VisualStream, TraversableStream, Token)
+
+-- Custom expectation function for ParseErrorBundle
+
+shouldBePretty
+  :: ( Stream s
+     , VisualStream s
+     , TraversableStream s
+     , ShowErrorComponent e
+     , Show e
+     , Eq a
+     , Show a
+     )
+  => Either (ParseErrorBundle s e) a
+  -> Either String a
+  -> Expectation
+shouldBePretty actual expected =
+  case (actual, expected) of
+    (Left actualErr, Left expectedErr) ->
+      let actualPretty = errorBundlePretty actualErr
+      in if actualPretty == expectedErr
+           then return ()
+           else expectationFailure $ "Expected:\n" ++ expectedErr ++ "\n\nBut got:\n" ++ actualPretty
+    (Right actualVal, Right expectedVal) ->
+      actualVal `shouldBe` expectedVal
+    (Left actualErr, Right _) ->
+      expectationFailure $
+        "Expected success but got error:\n" ++ errorBundlePretty actualErr
+    (Right actualVal, Left expectedErr) ->
+      expectationFailure $
+        "Expected error:\n" ++ expectedErr ++ "\n\nBut got success:\n" ++ show actualVal
+

--- a/test/UtilsSpec.hs
+++ b/test/UtilsSpec.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE OverloadedLists #-}
+
+module UtilsSpec where
+
+import Data.Map as M
+import Test.Hspec
+import Test.Hspec.QuickCheck
+import Test.QuickCheck
+import Utils (groupMap)
+
+spec :: Spec
+spec = describe "utils" $ do
+  it "groupMap" $
+    let
+      input :: [Int]
+      input = [1, 2, 3, 4, 5, 6]
+      expected :: M.Map Bool [Int]
+      expected = [(True, [20, 40, 60]), (False, [10, 30, 50])]
+     in
+      groupMap even (10 *) input `shouldBe` expected


### PR DESCRIPTION
fairly satisfied with the readability of the solutions, as both are essentially one-liners.

For developers who are not familiar with Haskell, there are probably two aspects that most affect **readability**:
* the wrapping and unwrapping of `getSum` / `Sum` to use `foldMap`. While this might feel unintuitive for those not accustomed to monoids and Haskell's support for them, I appreciate it because it avoids unnecessary list traversals (compared to functions like `sum`) while still offering a high-level abstraction.
* The presence of some `curry` / `uncurry` functions, which primarily arise from working with zipped lists.

In terms of **algorithmic complexity**, in the worst-case scenario (ignoring optimizations):  
* **part 1** is O(n * log n) , where n is the size of the input. The overall complexity is dominated by the sorting step.  The breakdown is as follows:  
  * Unzip takes O(n)
  * Sorting the two lists using `sort` takes O(n log n) each
  * zip adds an extra O(n) 
  * folding is also  O(n). the overall complexity is dominated by the sorting. 
* **part 2** is O(n * log k) , where`n` is the size of the input , and `k` the size of **unique** keys in the data. The overall complexity is dominated by the construction of the map to count the duplicated entries.  The breakdown is as follows:  
  * Unzip takes O(n)
  * precalculate the counts of all occurrences in a single traversal, takes O(n log k); if we count it on the fly, this would result instead in a O(n^2) complexity and one traversal for each entry in the other list
  * folding while calculating the similarity takes O(n). 

Note: 
* parsing of the input is already shared between the two parts—meaning the read and parse operations are performed only once. This is standard for all days, as AoC guarantees that the input is reused across both parts
* while in day 1 it would be possible to share also the first unzip operation between the parts, the decision was made to keep **part 1** and **part 2** independent to maintain separation of logic
* we use megaparsec to parse a single line at a time instead of using it to parse the full input at once. There are pros and cons of using `fmap parse . T.lines` instead of acting directly on the full input. One of the reasons I usually prefer it to keep this way is because if we wanna move to a streaming solution like `conduit` to process the input in constant memory we could do that 