### PR TITLE
Day 2

### DIFF
--- a/benchmarks/Day1Bench.hs
+++ b/benchmarks/Day1Bench.hs
@@ -14,9 +14,9 @@ values = [1000, 10_000, 100_000]
 benchmarks :: [Benchmark]
 benchmarks =
   [ bgroup
-      "part1"
+      "Day 1 part 1"
       (fmap (\n -> bench (show n) $ whnf part1 (generateInput n)) values)
   , bgroup
-      "part2"
+      "Day 1 part 2"
       (fmap (\n -> bench (show n) $ whnf part2 (generateInput n)) values)
   ]

--- a/benchmarks/Day2Bench.hs
+++ b/benchmarks/Day2Bench.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE NumericUnderscores #-}
+
+module Day2Bench (benchmarks) where
+
+import Criterion.Main
+import Day2 (part1, part2, Report(..), Level(..))
+
+generateInput :: Int -> Int -> [Report]
+generateInput numReports numLevels =
+  [ Report [Level(i + j) | j <- [1 .. numLevels]] | i <- [1 .. numReports] ]
+
+values :: [(Int, Int)]
+values = [(100, 1000), (1000, 1000), (5000, 1000)]
+
+benchmarks :: [Benchmark]
+benchmarks =
+  [ bgroup
+      "Day 2 part 1"
+      (fmap (\a -> bench (show a) $ whnf part1 (uncurry generateInput a)) values)
+  , bgroup
+      "Day 2 part 2"
+      (fmap (\a -> bench (show a) $ whnf part2 (uncurry generateInput a)) values)
+  ]

--- a/benchmarks/Main.hs
+++ b/benchmarks/Main.hs
@@ -2,6 +2,7 @@ module Main where
 
 import Criterion.Main
 import Day1Bench
+import Day2Bench
 
 main :: IO ()
-main = defaultMain (Day1Bench.benchmarks)
+main = defaultMain (Day1Bench.benchmarks ++ Day2Bench.benchmarks)

--- a/src/Day2.hs
+++ b/src/Day2.hs
@@ -1,11 +1,85 @@
-module Day2 where
+{-# LANGUAGE DerivingVia #-}
+
+module Day2 (Answer (..), Report (..), Level (..), program, logic, monotonic, boundPairwiseDistance, parseAll, parse, part1, part2, isReportSafe1, isReportSafe2, allButOne) where
+
+import Control.Applicative (many)
+import Data.List (inits, tails)
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
+import Data.Void (Void)
+import Text.Megaparsec (Parsec, optional, runParser)
+import Text.Megaparsec.Char (eol, space)
+import Text.Megaparsec.Char.Lexer (decimal)
+import Text.Megaparsec.Error (ParseErrorBundle)
 
 program :: FilePath -> IO ()
 program = (=<<) print . fmap logic . T.readFile
 
-data Answer = Answer deriving (Eq, Show)
+data Answer = Answer Int Int deriving (Eq, Show)
 
-logic :: T.Text -> Answer
-logic = const Answer
+answer :: [Report] -> Answer
+answer = Answer <$> part1 <*> part2
+
+newtype Level = Level Int
+  deriving (Eq, Show)
+  deriving (Ord, Num) via Int
+
+newtype Report = Report
+  { levels :: [Level]
+  }
+  deriving (Eq, Show)
+
+logic :: T.Text -> Either ParsingError Answer
+logic = fmap answer . parseAll
+
+part1 :: [Report] -> Int
+part1 = count isReportSafe1
+
+part2 :: [Report] -> Int
+part2 = count isReportSafe2
+
+count :: (a -> Bool) -> [a] -> Int
+count p = length . filter p
+
+monotonic :: (Ord a) => [a] -> Bool
+monotonic as = all (uncurry (>)) as' || all (uncurry (<)) as'
+ where
+  as' = zip as (tail as) -- safe on empty lists due to lazy evaluation
+
+distance :: (Num a) => a -> a -> a
+distance = (abs .) . (-)
+
+pairwiseDistance :: (Num a) => [a] -> [a]
+pairwiseDistance as = uncurry distance <$> zip as (tail as)
+
+boundPairwiseDistance :: (Ord a, Num a) => [a] -> Bool
+boundPairwiseDistance [] = True
+boundPairwiseDistance [_] = True
+boundPairwiseDistance as = maximum (pairwiseDistance as) <= 3
+
+isSafe1 :: (Ord a, Num a) => [a] -> Bool
+isSafe1 as = monotonic as && boundPairwiseDistance as
+
+isReportSafe1 :: Report -> Bool
+isReportSafe1 = isSafe1 . levels
+
+allButOne :: [a] -> [[a]]
+allButOne as = zipWith (++) (inits as) (drop 1 (tails as))
+
+isSafe2 :: (Ord a, Num a) => [a] -> Bool
+isSafe2 = any isSafe1 . allButOne
+
+isReportSafe2 :: Report -> Bool
+isReportSafe2 = isSafe2 . levels
+
+type Parser = Parsec Void T.Text
+type ParsingError = ParseErrorBundle T.Text Void
+
+parser :: Parser Report
+parser = Report <$> many (Level <$> (decimal <* space)) <* optional eol
+
+parse :: T.Text -> Either ParsingError Report
+parse = runParser parser "input file"
+
+parseAll :: T.Text -> Either ParsingError [Report]
+parseAll = traverse parse . T.lines

--- a/src/Day2.hs
+++ b/src/Day2.hs
@@ -1,9 +1,10 @@
 {-# LANGUAGE DerivingVia #-}
 
-module Day2 (Answer (..), Report (..), Level (..), program, logic, monotonic, boundPairwiseDistance, parseAll, parse, part1, part2, isReportSafe1, isReportSafe2, allButOne) where
+module Day2 (Answer (..), Report (..), Level (..), program, logic, monotonic, boundPairwiseDistance, parseLines, parseLine, part1, part2, isReportSafe1, isReportSafe2, allButOne) where
 
 import Control.Applicative (many)
-import Data.List (inits, tails)
+import Data.List (group, inits, tails)
+import qualified Data.List.NonEmpty as N
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import Data.Void (Void)
@@ -30,7 +31,7 @@ newtype Report = Report
   deriving (Eq, Show)
 
 logic :: T.Text -> Either ParsingError Answer
-logic = fmap answer . parseAll
+logic = fmap answer . parseLines
 
 part1 :: [Report] -> Int
 part1 = count isReportSafe1
@@ -42,20 +43,22 @@ count :: (a -> Bool) -> [a] -> Int
 count p = length . filter p
 
 monotonic :: (Ord a) => [a] -> Bool
-monotonic as = all (uncurry (>)) as' || all (uncurry (<)) as'
+monotonic = isNullOrSingleton . group . compareWithNext
  where
-  as' = zip as (tail as) -- safe on empty lists due to lazy evaluation
+  isNullOrSingleton [] = True
+  isNullOrSingleton [_] = True
+  isNullOrSingleton (_ : _) = False
+  compareWithNext :: (Ord b) => [b] -> [Ordering]
+  compareWithNext bs = zipWith compare bs (tail bs)
 
 distance :: (Num a) => a -> a -> a
 distance = (abs .) . (-)
 
-pairwiseDistance :: (Num a) => [a] -> [a]
-pairwiseDistance as = uncurry distance <$> zip as (tail as)
+pairwiseDistances :: (Num a) => [a] -> [a]
+pairwiseDistances as = uncurry distance <$> zip as (tail as)
 
 boundPairwiseDistance :: (Ord a, Num a) => [a] -> Bool
-boundPairwiseDistance [] = True
-boundPairwiseDistance [_] = True
-boundPairwiseDistance as = maximum (pairwiseDistance as) <= 3
+boundPairwiseDistance = maybe True ((<= 3) . maximum) . N.nonEmpty . pairwiseDistances
 
 isSafe1 :: (Ord a, Num a) => [a] -> Bool
 isSafe1 as = monotonic as && boundPairwiseDistance as
@@ -78,8 +81,8 @@ type ParsingError = ParseErrorBundle T.Text Void
 parser :: Parser Report
 parser = Report <$> many (Level <$> (decimal <* space)) <* optional eol
 
-parse :: T.Text -> Either ParsingError Report
-parse = runParser parser "input file"
+parseLine :: T.Text -> Either ParsingError Report
+parseLine = runParser parser "input file"
 
-parseAll :: T.Text -> Either ParsingError [Report]
-parseAll = traverse parse . T.lines
+parseLines :: T.Text -> Either ParsingError [Report]
+parseLines = traverse parseLine . T.lines

--- a/test/Day1Spec.hs
+++ b/test/Day1Spec.hs
@@ -3,11 +3,10 @@
 module Day1Spec where
 
 import qualified Data.Text as T
-import qualified Data.Text.IO as T
-import Day1 (Answer, Answer(..), logic, parse, part1, part2)
+import Day1 (logic, parse, part1, part2, Answer(..))
 import NeatInterpolation (trimming)
 import SpecUtils (shouldBePretty)
-import Test.Hspec (Expectation, Spec, describe, expectationFailure, it, shouldBe)
+import Test.Hspec (Spec, describe, it)
 import Test.Hspec.QuickCheck ()
 import Test.QuickCheck ()
 

--- a/test/Day2Spec.hs
+++ b/test/Day2Spec.hs
@@ -4,7 +4,7 @@ module Day2Spec where
 
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
-import Day2 (Answer (..), Level (..), Report (..), allButOne, boundPairwiseDistance, isReportSafe1, isReportSafe2, logic, monotonic, parse, parseAll, part1, part2)
+import Day2 (Answer (..), Level (..), Report (..), allButOne, boundPairwiseDistance, isReportSafe1, isReportSafe2, logic, monotonic, parseLine, parseLines, part1, part2)
 import NeatInterpolation (trimming)
 import SpecUtils (shouldBePretty)
 import Test.Hspec (Spec, describe, it, shouldBe, xit)
@@ -58,22 +58,22 @@ spec = describe "Day 2" $ do
     boundPairwiseDistance [9, 7, 6, 2, 1] `shouldBe` False
 
   it "parse line" $
-    parse "7 6 4 2 1" `shouldBePretty` Right (Report [7, 6, 4, 2, 1])
+    parseLine "7 6 4 2 1" `shouldBePretty` Right (Report [7, 6, 4, 2, 1])
 
   it "part 1 troubleshooting" $
-    fmap (fmap isReportSafe1) (parseAll example) `shouldBePretty` Right [True, False, False, False, False, True]
+    fmap (fmap isReportSafe1) (parseLines example) `shouldBePretty` Right [True, False, False, False, False, True]
 
   it "part 1" $
-    fmap part1 (parseAll example) `shouldBePretty` Right 2
+    fmap part1 (parseLines example) `shouldBePretty` Right 2
 
   it "allButOne" $
-    allButOne [1, 3, 2, 4, 5] `shouldBe` [[3, 2, 4, 5], [1, 2, 4, 5], [1, 3, 4, 5], [1, 3, 2, 5], [1,3,2,4]]
+    allButOne [1, 3, 2, 4, 5] `shouldBe` [[3, 2, 4, 5], [1, 2, 4, 5], [1, 3, 4, 5], [1, 3, 2, 5], [1, 3, 2, 4]]
 
   it "part 2 troubleshooting" $
-    fmap (fmap isReportSafe2) (parseAll example) `shouldBePretty` Right [True, False, False, True, True, True]
+    fmap (fmap isReportSafe2) (parseLines example) `shouldBePretty` Right [True, False, False, True, True, True]
 
   it "part 2" $
-    fmap part2 (parseAll example) `shouldBePretty` Right 4
+    fmap part2 (parseLines example) `shouldBePretty` Right 4
 
   it "logic" $
     logic example `shouldBePretty` Right (Answer 2 4)

--- a/test/Day2Spec.hs
+++ b/test/Day2Spec.hs
@@ -1,21 +1,76 @@
+{-# LANGUAGE QuasiQuotes #-}
+
 module Day2Spec where
 
-import Day2
-import Test.Hspec
-import Test.Hspec.QuickCheck
-import Test.QuickCheck
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
+import Day2 (Answer (..), Level (..), Report (..), allButOne, boundPairwiseDistance, isReportSafe1, isReportSafe2, logic, monotonic, parse, parseAll, part1, part2)
+import NeatInterpolation (trimming)
+import SpecUtils (shouldBePretty)
+import Test.Hspec (Spec, describe, it, shouldBe, xit)
+import Test.Hspec.QuickCheck ()
+import Test.QuickCheck ()
+
+example :: T.Text
+example =
+  [trimming|
+    7 6 4 2 1
+    1 2 7 8 9
+    9 7 6 2 1
+    1 3 2 4 5
+    8 6 4 4 1
+    1 3 6 7 9
+ |]
 
 spec :: Spec
 spec = describe "Day 2" $ do
-  it ""
-    $ 1
-    `shouldBe` 1
+  it "monotonic works on empty lists" $
+    monotonic ([] :: [Int]) `shouldBe` True
 
-  prop ""
-    $ \l -> reverse (reverse l) == (l :: [Int])
+  it "monotonic works on singleton lists" $
+    monotonic [1] `shouldBe` True
 
-  xit "solve the puzzle" $ do
-     input <- T.readFile "resources/input2"
-     logic input `shouldBe` Answer
+  it "monotonic increasing" $
+    monotonic [1, 4, 7, 9, 100] `shouldBe` True
+
+  it "monotonic decreasing" $
+    monotonic [100, 9, 7, 4, 1] `shouldBe` True
+
+  it "non monotonic (increasing an decreasing)" $
+    monotonic [1, 4, 7, 6, 100] `shouldBe` False
+
+  it "non monotonic (neither increasing or decreasing)" $
+    monotonic [1, 4, 7, 7, 100] `shouldBe` False
+
+  it "boundPairwiseDistance works on empty lists" $
+    boundPairwiseDistance ([] :: [Int]) `shouldBe` True
+
+  it "boundPairwiseDistance works on singleton lists" $
+    boundPairwiseDistance [1] `shouldBe` True
+
+  it "boundPairwiseDistance ok" $
+    boundPairwiseDistance [7, 6, 4, 2, 1] `shouldBe` True
+
+  it "boundPairwiseDistance not ok (increase of 5)" $
+    boundPairwiseDistance [1, 2, 7, 8, 9] `shouldBe` False
+
+  it "boundPairwiseDistance not ok (decrease of 4)" $
+    boundPairwiseDistance [9, 7, 6, 2, 1] `shouldBe` False
+
+  it "parse line" $
+    parse "7 6 4 2 1" `shouldBePretty` Right (Report [7, 6, 4, 2, 1])
+
+  it "part 1 troubleshooting" $
+    fmap (fmap isReportSafe1) (parseAll example) `shouldBePretty` Right [True, False, False, False, False, True]
+
+  it "part 1" $
+    fmap part1 (parseAll example) `shouldBePretty` Right 2
+
+  it "allButOne" $
+    allButOne [1, 3, 2, 4, 5] `shouldBe` [[3, 2, 4, 5], [1, 2, 4, 5], [1, 3, 4, 5], [1, 3, 2, 5], [1,3,2,4]]
+
+  it "part 2 troubleshooting" $
+    fmap (fmap isReportSafe2) (parseAll example) `shouldBePretty` Right [True, False, False, True, True, True]
+
+  it "part 2" $
+    fmap part2 (parseAll example) `shouldBePretty` Right 4

--- a/test/Day2Spec.hs
+++ b/test/Day2Spec.hs
@@ -74,3 +74,6 @@ spec = describe "Day 2" $ do
 
   it "part 2" $
     fmap part2 (parseAll example) `shouldBePretty` Right 4
+
+  it "logic" $
+    logic example `shouldBePretty` Right (Answer 2 4)


### PR DESCRIPTION
The second part is a nice example of how comonads allow to define lazily all the possible combinations, and how fp allows to reuse the existing solution for part1 completely: we just have to lift that into the comonadic context. To keep the notation not too heavy, instead of importing comonads and using zippers, the trick is implemented directly using `inits` and `tails`.

Notice: the `allButOne` method does not include the original list. This is not a problem for this exercise, as if the full list satisfies the requirements then also all the sublists do. However it would be nice to make this property clearer, eg, using PBTs

no benchmark or performance consideration in this PR, although the laziness of inits and tails should do the trick. Maybe ill explore more in another PR