### PR TITLE
Added CLI subcommand parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ stack exec aoc2024
 ```
 or passing arguments
 ```
-stack exec aoc2024 -- -d <day> -f <filename> 
+stack exec aoc2024 -- run -d <day> -f <filename> 
 ```
 
 For **faster feedback loop**,
@@ -48,7 +48,11 @@ To install the executable under `~/.local/bin`,
 ```
  stack install
 ```
-and the executable can be run with `aoc2024` or passing arguments like `aoc2024 -d 1 -f inputs/day1`, assuming `~/.local/bin` is in the `$PATH` variable. 
+and the executable can be run with `aoc2024` or passing arguments like 
+```
+aoc2024 run -d 1 -f inputs/day1
+```
+assuming `~/.local/bin` is in the `$PATH` variable. 
 
 To run **ghci** (with a version compatible with the resolver) run
 ```

--- a/src/App.hs
+++ b/src/App.hs
@@ -1,32 +1,33 @@
 module App where
 
-import Args 
-import Options.Applicative ( handleParseResult )
+import Args
+import Day1 (program)
+import Day10 (program)
+import Day2 (program)
+import Day3 (program)
+import Day4 (program)
+import Day5 (program)
+import Day6 (program)
+import Day7 (program)
+import Day8 (program)
+import Day9 (program)
+import Options.Applicative (handleParseResult)
 import System.Environment (getArgs)
-import Day1 ( program )
-import Day2 ( program )
-import Day3 ( program )
-import Day4 ( program )
-import Day5 ( program )
-import Day6 ( program )
-import Day7 ( program )
-import Day8 ( program )
-import Day9 ( program )
-import Day10 ( program )
 
 program :: IO ()
 program =
   getArgs >>= (handleParseResult . parseArgs) >>= program'
 
-program' :: Args -> IO ()
-program' (Args 1 f) = Day1.program f
-program' (Args 2 f) = Day2.program f
-program' (Args 3 f) = Day3.program f
-program' (Args 4 f) = Day4.program f
-program' (Args 5 f) = Day5.program f
-program' (Args 6 f) = Day6.program f
-program' (Args 7 f) = Day7.program f
-program' (Args 8 f) = Day8.program f
-program' (Args 9 f) = Day9.program f
-program' (Args 10 f) = Day10.program f
-program' _ = putStrLn "day not found"
+program' :: Command -> IO ()
+program' (Run (Args 1 f)) = Day1.program f
+program' (Run (Args 2 f)) = Day2.program f
+program' (Run (Args 3 f)) = Day3.program f
+program' (Run (Args 4 f)) = Day4.program f
+program' (Run (Args 5 f)) = Day5.program f
+program' (Run (Args 6 f)) = Day6.program f
+program' (Run (Args 7 f)) = Day7.program f
+program' (Run (Args 8 f)) = Day8.program f
+program' (Run (Args 9 f)) = Day9.program f
+program' (Run (Args 10 f)) = Day10.program f
+program' (Run (Args _ _)) = putStrLn "day not found"
+program' (Generate (GenerateArgs _)) = putStrLn "not implemented yet"

--- a/src/Args.hs
+++ b/src/Args.hs
@@ -1,23 +1,57 @@
 module Args where
+
 import Options.Applicative
 
-data Args = Args {
-   day :: Int,
-   input :: FilePath
-   } deriving (Eq,Show)
+data Command
+  = Run Args
+  | Generate GenerateArgs
+  deriving (Eq, Show)
+
+data Args = Args
+  { day :: Int
+  , input :: FilePath
+  }
+  deriving (Eq, Show)
+
+newtype GenerateArgs = GenerateArgs Int deriving (Eq, Show)
 
 argsParser :: Parser Args
-argsParser = Args <$> option auto
-            ( long "day"
-           <> short 'd'
-           <> help "day" ) <*> strOption ( long "filename"
-           <> short 'f'
-           <> help "filename" )
+argsParser =
+  Args
+    <$> option
+      auto
+      ( long "day"
+          <> short 'd'
+          <> help "day"
+      )
+    <*> strOption
+      ( long "filename"
+          <> short 'f'
+          <> help "filename"
+      )
+
+generateArgsParser :: Parser GenerateArgs
+generateArgsParser =
+  GenerateArgs
+    <$> option
+      auto
+      ( long "day"
+          <> short 'd'
+          <> help "day"
+      )
+
+commandParser :: Parser Command
+commandParser =
+  hsubparser
+    ( command "run" (info (Run <$> argsParser) (progDesc "run the solution to the puzzle"))
+        <> command "generate" (info (Generate <$> generateArgsParser) (progDesc "generate scaffolding from template for a given day"))
+    )
 
 withInfo :: Parser a -> String -> ParserInfo a
-withInfo p s = info (helper <*> p) (fullDesc  <> progDesc s)
+withInfo p s = info (helper <*> p) (fullDesc <> progDesc s)
 
-parseArgs :: [String] -> ParserResult Args
-parseArgs = execParserPure preferences parserInfo where
-   parserInfo = withInfo argsParser "Advent of code"
-   preferences = prefs (disambiguate <> showHelpOnEmpty <> showHelpOnError)
+parseArgs :: [String] -> ParserResult Command
+parseArgs = execParserPure preferences parserInfo
+ where
+  parserInfo = withInfo commandParser "Advent of code 2024 CLI"
+  preferences = prefs (disambiguate <> showHelpOnEmpty <> showHelpOnError)

--- a/test/ArgsSpec.hs
+++ b/test/ArgsSpec.hs
@@ -1,19 +1,21 @@
 module ArgsSpec where
 
 import Args
+import Options.Applicative (ParserResult (Failure, Success))
 import Test.Hspec
 import Test.Hspec.QuickCheck
 import Test.QuickCheck.Property
-import Options.Applicative (ParserResult(Success))
-import Options.Applicative (ParserResult(Failure))
 
-parseArgsMaybe = transform . parseArgs where
+parseArgsMaybe = transform . parseArgs
+ where
   transform (Success a) = Right a
   transform (Failure failure) = Left (show failure)
   transform _ = Left "completion"
 
 spec :: Spec
 spec = describe "Args parser" $ do
+  it "is able to parse a valid command to run the solution" $
+    parseArgsMaybe ["run", "-d", "1", "-f", "file"] `shouldBe` Right (Run (Args 1 "file"))
 
-     it "is able to parse a valid command" $
-        parseArgsMaybe ["-d", "1", "-f", "file"] `shouldBe` Right (Args 1 "file")
+  it "is able to parse a valid command to generate the scaffolding for a new day" $
+    parseArgsMaybe ["generate", "-d", "1"] `shouldBe` Right (Generate (GenerateArgs 1))


### PR DESCRIPTION
Im considering adding extra capabilities to the aoc2024 cli, including the possibility to generate project files from a template (so i don't have to copy paste files around). For now, the new capabilities are NOT implemented yet, this PR starts by organising command-line options into subcommands