### PR TITLE
Day 3

### DIFF
--- a/src/Day3.hs
+++ b/src/Day3.hs
@@ -1,11 +1,71 @@
 module Day3 where
+
+import Control.Applicative (Alternative ((<|>)), many)
+import Data.Foldable (Foldable (foldl'))
+import Data.Semigroup (Sum (..))
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
+import Data.Void (Void)
+import Text.Megaparsec (MonadParsec (try), Parsec, anySingle, runParser, skipManyTill)
+import Text.Megaparsec.Char (char, string)
+import Text.Megaparsec.Char.Lexer (decimal)
+import Text.Megaparsec.Error (ParseErrorBundle)
+import Witherable (mapMaybe)
 
 program :: FilePath -> IO ()
 program = (=<<) print . fmap logic . T.readFile
 
-data Answer = Answer deriving (Eq, Show)
+data Answer = Answer Int Int deriving (Eq, Show)
 
-logic :: T.Text -> Answer
-logic = const Answer
+answer :: [Operation] -> Answer
+answer = Answer <$> part1 <*> part2
+
+logic :: T.Text -> Either ParsingError Answer
+logic = fmap answer . parseAll
+
+data Operation
+  = Mul Int Int
+  | Do
+  | Dont
+  deriving (Eq, Show)
+
+data ArithmeticOperation = Multiply Int Int deriving (Eq, Show)
+
+eval :: ArithmeticOperation -> Int
+eval (Multiply a b) = a * b
+
+evalAll :: [ArithmeticOperation] -> Int
+evalAll = getSum . foldMap (Sum . eval)
+
+part1 :: [Operation] -> Int
+part1 = evalAll . mapMaybe ignoreDoDontOperations
+ where
+  ignoreDoDontOperations (Mul a b) = Just (Multiply a b)
+  ignoreDoDontOperations _ = Nothing
+
+part2 :: [Operation] -> Int
+part2 = evalAll . includeDoDontOperations
+
+includeDoDontOperations :: [Operation] -> [ArithmeticOperation]
+includeDoDontOperations = reverse . snd . foldl' accumulate (True, [])
+ where
+  accumulate :: (Bool, [ArithmeticOperation]) -> Operation -> (Bool, [ArithmeticOperation])
+  accumulate (True, accumulated) (Mul a b) = (True, Multiply a b : accumulated)
+  accumulate (False, accumulated) (Mul _ _) = (False, accumulated)
+  accumulate (_, accumulated) Dont = (False, accumulated)
+  accumulate (_, accumulated) Do = (True, accumulated)
+
+type Parser = Parsec Void T.Text
+type ParsingError = ParseErrorBundle T.Text Void
+
+parser :: Parser [Operation]
+parser = many (try (skipManyTill anySingle (try operationParser)))
+
+operationParser :: Parser Operation
+operationParser =
+  (Dont <$ string "don't()")
+    <|> (Do <$ string "do()")
+    <|> (Mul <$> (string "mul(" *> decimal <* char ',') <*> (decimal <* char ')'))
+
+parseAll :: T.Text -> Either ParsingError [Operation]
+parseAll = runParser parser "input file"

--- a/src/Day3.hs
+++ b/src/Day3.hs
@@ -1,7 +1,6 @@
 module Day3 where
 
 import Control.Applicative (Alternative ((<|>)), many)
-import Data.Bifunctor (Bifunctor (bimap))
 import Data.Foldable (Foldable (foldl'))
 import Data.Semigroup (Sum (..))
 import qualified Data.Text as T

--- a/test/Day3Spec.hs
+++ b/test/Day3Spec.hs
@@ -51,8 +51,20 @@ spec = describe "Day 3" $ do
   it "can parse mul(decimal,decimal) in part2" $
     parseAll example2 `shouldBePretty` Right expected2
 
-  it "map including do/dont operations" $
+  it "interpreting do/dont operations" $
     interpreter expected2 `shouldBe` [Multiply 2 4, Multiply 8 5]
+
+  it "troubleshoot interpreting do/dont: show memory state" $
+    -- scanl is not space-safe, don't use it in prod code
+    scanl run empty (fmap fromInstruction expected2)
+      `shouldBe` [ empty
+                 , Memory On [Multiply 2 4]
+                 , Memory Off [Multiply 2 4]
+                 , Memory Off [Multiply 2 4]
+                 , Memory Off [Multiply 2 4]
+                 , Memory On [Multiply 2 4]
+                 , Memory On [Multiply 8 5, Multiply 2 4]
+                 ]
 
   it "answer part 1" $
     logic example1 `shouldBePretty` Right (Answer 161 161)

--- a/test/Day3Spec.hs
+++ b/test/Day3Spec.hs
@@ -10,13 +10,13 @@ import Test.Hspec (Spec, describe, it, shouldBe)
 example1 :: T.Text
 example1 = "xmul(2,4)%&mul[3,7]!@^do_not_mul(5,5)+mul(32,64]then(mul(11,8)mul(8,5))"
 
-expected1 :: [Operation]
+expected1 :: [Instruction]
 expected1 = [Mul 2 4, Mul 5 5, Mul 11 8, Mul 8 5]
 
 example2 :: T.Text
 example2 = "xmul(2,4)&mul[3,7]!^don't()_mul(5,5)+mul(32,64](mul(11,8)undo()?mul(8,5))"
 
-expected2 :: [Operation]
+expected2 :: [Instruction]
 expected2 = [Mul 2 4, Dont, Mul 5 5, Mul 11 8, Do, Mul 8 5]
 
 spec :: Spec
@@ -52,7 +52,7 @@ spec = describe "Day 3" $ do
     parseAll example2 `shouldBePretty` Right expected2
 
   it "map including do/dont operations" $
-    includeDoDontOperations expected2 `shouldBe` [Multiply 2 4, Multiply 8 5]
+    interpreter expected2 `shouldBe` [Multiply 2 4, Multiply 8 5]
 
   it "answer part 1" $
     logic example1 `shouldBePretty` Right (Answer 161 161)


### PR DESCRIPTION
Notes: 
* Parser combinators offer an elegant way to express parsing logic in a concise, single line. However, in this PR I'm extensively rely on backtracking (e.g., using a nested `try`) to handle partially corrupted instructions like `mul(4,3` (missing a closing `)`). Backtracking makes performance and complexity harder to reason about, so the solution although elegant and concise the solution has drawbacks. I haven't explored in details whether the parser can be refactor in a better way
* While the first part is essentially just parsing, the second part has interesting logic too.While it’s possible to handle this directly in the parsing phase by leveraging the parser's statefulness, I opted against it. Mixing parsing and processing responsibilities reduces the reusability of the parser. There is interesting structure to explore in this part: The DO/DON’T logic is non-commutative, so it’s crucial to traverse the list of instructions from left to right, as order matters. To achieve this, I used `foldl'` appending to the list during accumulation for O(1) efficiency. This requires an additional `reverse` operation on the final result to correct the order. The left bias of the operation means also that probably there's no monoid or semigroup structure that can be useful here. I've tried to use `(Toggle, [ArithmeticOperation])`, but the standard semigroup instance on a pair handle the composition of the two components independently, while in our case we can't factorised the two operations, as the append `++` on lists is enabled or disabled based on the toggle 