### PR TITLE
Day 4 part 2 (the naive way)

### DIFF
--- a/src/Day4.hs
+++ b/src/Day4.hs
@@ -8,10 +8,10 @@ import Witherable (mapMaybe)
 program :: FilePath -> IO ()
 program = (=<<) print . fmap logic . T.readFile
 
-data Answer = Answer Int deriving (Eq, Show)
+data Answer = Answer Int Int deriving (Eq, Show)
 
 answer :: Grid Char -> Answer
-answer = Answer . part1
+answer = Answer <$> part1 <*> part2
 
 logic :: T.Text -> Answer
 logic = answer . parseGrid
@@ -63,10 +63,51 @@ backwardDiagonals = diagonals . Grid . fmap reverse . grid
 findOccurrences :: ([a] -> Maybe b) -> Grid a -> Occurrences b
 findOccurrences p =
   Occurrences
-    <$> (concatMap (mapMaybe p . tails) . rows)
-    <*> (concatMap (mapMaybe p . tails) . columns)
+    <$> concatMap (mapMaybe p . tails) . rows
+    <*> concatMap (mapMaybe p . tails) . columns
     <*> mapMaybe p . diagonals -- no need for tails: we already precalculate partial diagonals
     <*> mapMaybe p . backwardDiagonals
+
+-- Part 2 --
+
+type Square3 a = ((a, a, a), (a, a, a), (a, a, a))
+
+squares3 :: [[a]] -> [Square3 a]
+squares3 = concatMap groupColumns3 . groupRows3
+ where
+  groupRows3 :: [[a]] -> [[(a, a, a)]]
+  groupRows3 = fmap toPair3 . tails
+  toPair3 :: [[a]] -> [(a, a, a)]
+  toPair3 (a1 : a2 : a3 : _) = zip3 a1 a2 a3
+  toPair3 _ = []
+  groupColumns3 = mapMaybe extractFirst3 . tails
+  extractFirst3 :: [a] -> Maybe (a, a, a)
+  extractFirst3 (a1 : a2 : a3 : _) = Just (a1, a2, a3)
+  extractFirst3 _ = Nothing
+
+isSquare3Matching :: Square3 (a -> Bool) -> Square3 a -> Bool
+isSquare3Matching ((p1, p2, p3), (p4, p5, p6), (p7, p8, p9)) ((a1, a2, a3), (a4, a5, a6), (a7, a8, a9)) = p1 a1 && p2 a2 && p3 a3 && p4 a4 && p5 a5 && p6 a6 && p7 a7 && p8 a8 && p9 a9
+
+isSquare3MatchingAny :: [Square3 (a -> Bool)] -> Square3 a -> Bool
+isSquare3MatchingAny expected input = any ((flip isSquare3Matching) input) expected
+
+validSquare3 :: [Square3 (Char -> Bool)]
+validSquare3 =
+  [ ((is 'M', anything, is 'M'), (anything, is 'A', anything), (is 'S', anything, is 'S'))
+  , ((is 'S', anything, is 'S'), (anything, is 'A', anything), (is 'M', anything, is 'M'))
+  , ((is 'M', anything, is 'S'), (anything, is 'A', anything), (is 'M', anything, is 'S'))
+  , ((is 'S', anything, is 'M'), (anything, is 'A', anything), (is 'S', anything, is 'M'))
+  ]
+ where
+  is :: Char -> Char -> Bool
+  is = (==)
+  anything :: Char -> Bool
+  anything = const True
+
+part2 :: Grid Char -> Int
+part2 = length . filter (isSquare3MatchingAny validSquare3) . squares3 . grid
+
+-- Input parsing --
 
 parse :: String -> Maybe Xmas
 parse ('X' : 'M' : 'A' : 'S' : _) = Just Xmas

--- a/test/Day4Spec.hs
+++ b/test/Day4Spec.hs
@@ -150,8 +150,20 @@ spec = describe "Day 4" $ do
         , backwardDiagonal = [Samx, Xmas, Samx, Samx, Samx]
         }
 
+  -- MSXA
+  -- MSAM
+  -- AMXS
+  it "get squares" $
+    squares3 (fmap T.unpack (T.lines simple))
+      `shouldBe` [ (('M', 'M', 'A'), ('S', 'S', 'M'), ('X', 'A', 'X'))
+                 , (('S', 'S', 'M'), ('X', 'A', 'X'), ('A', 'M', 'S'))
+                 ]
+
   it "part1" $
     (part1 . parseGrid) example `shouldBe` 18
 
+  it "part2" $
+    (part2 . parseGrid) example `shouldBe` 9
+
   it "logic" $
-    logic example `shouldBe` Answer 18
+    logic example `shouldBe` (Answer 18 9)


### PR DESCRIPTION
Few observations:
* the index-less approach adopted for part 1 and continued here has pros and cons. Indexes can get messy, and are error prone, that being said though, I'm not satisfied yet with this approach in terms of readability, performance, extensibility, etc. It's just hard to visualise what's going on "geometrically" with some of the operations that I provide, and that uses `inits`, `tails`, `zip` etc. Al of this as already been discussed lengthly in https://github.com/alessandrocandolini/advent-of-code2024/pull/12 All  in all the approach surely requires some redesign and rethinking (that goes beyond a simple cleanup), I hope I will have time to think about it and polish the structure in other PRs. 
* part 2 could have been solved with a fully comonadic approach, as it "only" requires near neighbourhoods (compared to part1 where columns, rows, and diagonals could extend a dynamic number of times depending on the word to match). However, i've tried to just stay with the approach already started in part 1
