### PR TITLE
Mealy machine for day 3 part 2

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -21,6 +21,7 @@ dependencies:
 - comonad
 - adjunctions
 - logict
+- machines
 
 default-extensions:
 - OverloadedStrings

--- a/test/Day3Spec.hs
+++ b/test/Day3Spec.hs
@@ -51,21 +51,6 @@ spec = describe "Day 3" $ do
   it "can parse mul(decimal,decimal) in part2" $
     parseAll example2 `shouldBePretty` Right expected2
 
-  it "interpreting do/dont operations" $
-    interpreter expected2 `shouldBe` [Multiply 2 4, Multiply 8 5]
-
-  it "troubleshoot interpreting do/dont: show memory state" $
-    -- scanl is not space-safe, don't use it in prod code
-    scanl run empty (fmap fromInstruction expected2)
-      `shouldBe` [ empty
-                 , Memory On [Multiply 2 4]
-                 , Memory Off [Multiply 2 4]
-                 , Memory Off [Multiply 2 4]
-                 , Memory Off [Multiply 2 4]
-                 , Memory On [Multiply 2 4]
-                 , Memory On [Multiply 8 5, Multiply 2 4]
-                 ]
-
   it "answer part 1" $
     logic example1 `shouldBePretty` Right (Answer 161 161)
   it "answer part 2" $


### PR DESCRIPTION
Simplify the code by leveraging Mealy machines to handle state transitions efficiently.

Initially, I considered using a Moore machine (hence the branch name `moore`), which would maintain both the toggle state (on/off) and the accumulated output list in its state. The motivation was to handle do and dont elements, which solely affect the toggle state without producing any output. However, the ergonomics of Moore machines proved more complex compared to Mealy machines. Consequently, I chose to stick with Mealy machines, representing the lack of output using Maybe