### PR TITLE
fetching stats

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -23,6 +23,12 @@ dependencies:
 - machines
 - algebraic-graphs
 - ansi-terminal
+- envparse
+- req
+- bytestring
+- mtl
+- aeson
+- aeson-pretty
 
 default-extensions:
 - OverloadedStrings

--- a/src/App.hs
+++ b/src/App.hs
@@ -1,6 +1,13 @@
 module App where
 
-import Args
+import Args (
+  Args (Args),
+  Command (..),
+  GenerateArgs (GenerateArgs),
+  StatsArgs (StatsArgs),
+  parseArgs,
+ )
+import CodeGenerator (program)
 import Day1 (program)
 import Day10 (program)
 import Day2 (program)
@@ -12,6 +19,7 @@ import Day7 (program)
 import Day8 (program)
 import Day9 (program)
 import Options.Applicative (handleParseResult)
+import Stats (program)
 import System.Environment (getArgs)
 
 program :: IO ()
@@ -30,4 +38,5 @@ program' (Run (Args 8 f)) = Day8.program f
 program' (Run (Args 9 f)) = Day9.program f
 program' (Run (Args 10 f)) = Day10.program f
 program' (Run (Args _ _)) = putStrLn "day not found"
-program' (Generate (GenerateArgs _)) = putStrLn "not implemented yet"
+program' (Generate (GenerateArgs d)) = CodeGenerator.program d
+program' (GetStats (StatsArgs year export)) = Stats.program year export

--- a/src/Args.hs
+++ b/src/Args.hs
@@ -5,6 +5,7 @@ import Options.Applicative
 data Command
   = Run Args
   | Generate GenerateArgs
+  | GetStats StatsArgs
   deriving (Eq, Show)
 
 data Args = Args
@@ -14,6 +15,8 @@ data Args = Args
   deriving (Eq, Show)
 
 newtype GenerateArgs = GenerateArgs Int deriving (Eq, Show)
+data StatsRender = ConsoleRender | JsonRender deriving (Eq, Show)
+data StatsArgs = StatsArgs Int StatsRender deriving (Eq, Show)
 
 argsParser :: Parser Args
 argsParser =
@@ -39,12 +42,30 @@ generateArgsParser =
           <> short 'd'
           <> help "day"
       )
+statsArgsParser :: Parser StatsArgs
+statsArgsParser =
+  StatsArgs
+    <$> option
+      auto
+      ( long "year"
+          <> short 'y'
+          <> value 2024
+          <> showDefault
+          <> help "year"
+      )
+    <*> flag
+      ConsoleRender
+      JsonRender
+      ( long "json"
+          <> help "Export as json"
+      )
 
 commandParser :: Parser Command
 commandParser =
   hsubparser
     ( command "run" (info (Run <$> argsParser) (progDesc "run the solution to the puzzle"))
         <> command "generate" (info (Generate <$> generateArgsParser) (progDesc "generate scaffolding from template for a given day"))
+        <> command "stats" (info (GetStats <$> statsArgsParser) (progDesc "retrieve stats from the AOC website"))
     )
 
 withInfo :: Parser a -> String -> ParserInfo a

--- a/src/CodeGenerator.hs
+++ b/src/CodeGenerator.hs
@@ -1,0 +1,4 @@
+module CodeGenerator where
+
+program :: Int -> IO()
+program _ = putStrLn "not implemented yet"

--- a/src/Stats.hs
+++ b/src/Stats.hs
@@ -1,0 +1,150 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+
+module Stats where
+
+import Args (StatsRender (..))
+import Control.Monad ((<=<))
+import Control.Monad.Except (ExceptT (..), runExceptT)
+import Data.Aeson (ToJSON, toJSON)
+import Data.Aeson.Encode.Pretty (encodePretty)
+import Data.Aeson.Types (Value)
+import Data.Bifunctor (first)
+import qualified Data.ByteString.Char8 as B8
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as TE
+import qualified Data.Text.IO as T
+import qualified Data.Text.Lazy as TL
+import qualified Data.Text.Lazy.Encoding as TLE
+import Data.Void (Void)
+import qualified Env
+import GHC.Generics (Generic)
+import Network.HTTP.Req (
+  GET (GET),
+  NoReqBody (NoReqBody),
+  bsResponse,
+  defaultHttpConfig,
+  header,
+  https,
+  req,
+  responseBody,
+  responseStatusCode,
+  runReq,
+  (/:),
+ )
+import System.Exit (exitFailure, exitSuccess)
+import Text.Megaparsec (MonadParsec (try), Parsec, anySingle, errorBundlePretty, manyTill, runParser)
+import Text.Megaparsec.Char (char, string)
+import Text.Megaparsec.Char.Lexer (decimal)
+import Text.Megaparsec.Error (ParseErrorBundle)
+
+newtype StarsCount = StarsCount {count :: Int}
+  deriving (Eq, Show, Num) via Int
+
+newtype Stats = Stats {starsCount :: StarsCount}
+  deriving (Eq, Show)
+
+renderSuccessOrError :: StatsRender -> Either StatsError Stats -> T.Text
+renderSuccessOrError _ (Left (Not200 s)) = T.pack ("Unexpected HTTP status code response: " ++ show s)
+renderSuccessOrError _ (Left (CannotFindNumberOfStars p)) = T.pack (errorBundlePretty p)
+renderSuccessOrError ConsoleRender (Right stats) = consoleRender stats
+renderSuccessOrError JsonRender (Right stats) = jsonRender stats
+
+consoleRender :: Stats -> T.Text
+consoleRender =
+  ("stars:" <>)
+    . T.pack
+    . show
+    . count
+    . starsCount
+
+jsonToText :: Value -> T.Text
+jsonToText = TL.toStrict . TLE.decodeUtf8 . encodePretty
+
+jsonRender :: Stats -> T.Text
+jsonRender = jsonToText . toJSON . toShieldConfig
+
+newtype StatsEnvVariables = StatsEnvVariables
+  {session :: String}
+  deriving (Eq, Show)
+
+data ShieldsConfig = ShieldsConfig
+  { schemaVersion :: Int
+  , label :: String
+  , message :: String
+  , color :: String
+  }
+  deriving (Eq, Show, Generic)
+
+instance ToJSON ShieldsConfig
+
+defaultShieldsConfig :: String -> ShieldsConfig
+defaultShieldsConfig m =
+  ShieldsConfig
+    { schemaVersion = 1
+    , label = "stars ⭐️"
+    , message = m
+    , color = "green"
+    }
+
+toShieldConfig :: Stats -> ShieldsConfig
+toShieldConfig =
+  defaultShieldsConfig
+    . show
+    . count
+    . starsCount
+
+data StatsError
+  = Not200 Int
+  | CannotFindNumberOfStars ParsingError
+  deriving (Eq, Show)
+
+statsEnvVariablesParser :: Env.Parser Env.Error StatsEnvVariables
+statsEnvVariablesParser =
+  StatsEnvVariables
+    <$> Env.var (Env.str <=< Env.nonempty) "AOC_SESSION" (Env.help "Value of the session cookie, used for login")
+
+program :: Int -> StatsRender -> IO ()
+program year render = do
+  config <- Env.parse (Env.header "AOC stats requires env variables") statsEnvVariablesParser
+  stats <- runExceptT $ program' year config
+  T.putStrLn (renderSuccessOrError render stats) *> exit stats
+ where
+  exit (Left _) = exitFailure
+  exit (Right _) = exitSuccess
+
+program' :: Int -> StatsEnvVariables -> ExceptT StatsError IO Stats
+program' year envVariables =
+  ExceptT (uncurry parseIf200 <$> fetchPage year (session envVariables))
+
+parseIf200 :: Int -> T.Text -> Either StatsError Stats
+parseIf200 200 = first CannotFindNumberOfStars . parse
+parseIf200 status = const (Left (Not200 status))
+
+fetchPage :: Int -> String -> IO (Int, T.Text)
+fetchPage year s = runReq defaultHttpConfig $ do
+  let url = https "adventofcode.com" /: T.pack (show year)
+      cookieHeader = B8.pack ("session=" ++ s)
+  response <- req GET url NoReqBody bsResponse (header "Cookie" cookieHeader)
+  let body = TE.decodeUtf8 $ responseBody response
+      status = responseStatusCode response
+  pure (status, body)
+
+-- parsing
+type Parser = Parsec Void T.Text
+type ParsingError = ParseErrorBundle T.Text Void
+
+starsCountParser :: Parser StarsCount
+starsCountParser =
+  StarsCount
+    <$> ( manyTill anySingle (try (string "<span class=\"star-count\">"))
+            *> decimal
+            <* char '*'
+            <* string "</span>"
+        )
+
+statsParser :: Parser Stats
+statsParser = Stats <$> starsCountParser
+
+parse :: T.Text -> Either ParsingError Stats
+parse = runParser statsParser "html"

--- a/test/ArgsSpec.hs
+++ b/test/ArgsSpec.hs
@@ -19,3 +19,12 @@ spec = describe "Args parser" $ do
 
   it "is able to parse a valid command to generate the scaffolding for a new day" $
     parseArgsMaybe ["generate", "-d", "1"] `shouldBe` Right (Generate (GenerateArgs 1))
+
+  it "is able to parse a valid command to retrieve stats (without export)" $
+    parseArgsMaybe ["stats", "-y", "2022"] `shouldBe` Right (GetStats (StatsArgs 2022 ConsoleRender))
+
+  it "is able to parse a valid command to retrieve stats (with export)" $
+    parseArgsMaybe ["stats", "-y", "2022", "--json"] `shouldBe` Right (GetStats (StatsArgs 2022 JsonRender))
+
+  it "is able to parse a valid command to retrieve stats (with export and without year)" $
+    parseArgsMaybe ["stats", "--json"] `shouldBe` Right (GetStats (StatsArgs 2024 JsonRender))

--- a/test/StatsSpec.hs
+++ b/test/StatsSpec.hs
@@ -1,0 +1,124 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+module StatsSpec where
+
+import Args (StatsRender (..))
+import Data.Either (isLeft)
+import Data.Maybe (fromMaybe)
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+import qualified Env
+import NeatInterpolation (trimming)
+import SpecUtils (shouldBePretty)
+import Stats (Stats (..), StatsEnvVariables (..), StatsError (..), parse, parseIf200, renderSuccessOrError, statsEnvVariablesParser)
+import Test.Hspec (Spec, describe, it, shouldBe, shouldSatisfy)
+import Test.Hspec.QuickCheck ()
+import Test.QuickCheck ()
+
+exampleRender :: T.Text
+exampleRender =
+  [trimming|
+{
+    "color": "green",
+    "label": "stars ⭐️",
+    "message": "10",
+    "schemaVersion": 1
+}
+|]
+
+parsingErrorExample :: T.Text
+parsingErrorExample =
+  [trimming|
+html:10:12:
+   |
+10 | </head><!--
+   |            ^
+unexpected end of input
+expecting "<span class="star-count">"
+
+|]
+
+example :: T.Text
+example =
+  [trimming|
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+<meta charset="utf-8"/>
+<title>Advent of Code 2024</title>
+<link rel="stylesheet" type="text/css" href="/static/style.css?31"/>
+<link rel="stylesheet alternate" type="text/css" href="/static/highcontrast.css?1" title="High Contrast"/>
+<link rel="shortcut icon" href="/favicon.png"/>
+<script>window.addEventListener('click', function(e,s,r){if(e.target.nodeName==='CODE'&&e.detail===3){s=window.getSelection();s.removeAllRanges();r=document.createRange();r.selectNodeContents(e.target);s.addRange(r);}});</script>
+</head><!--
+-->
+<body>
+<header><div><h1 class="title-global"><a href="/">Advent of Code</a></h1><nav><ul><li><a href="/2024/about">[About]</a></li><li><a href="/2024/events">[Events]</a></li><li><a href="https://cottonbureau.com/people/advent-of-code" target="_blank">[Shop]</a></li><li><a href="/2024/settings">[Settings]</a></li><li><a href="/2024/auth/logout">[Log Out]</a></li></ul></nav><div class="user">Alessandro Candolini <span class="star-count">10*</span></div></div><div><h1 class="title-event">&nbsp;&nbsp;&nbsp;<span class="title-event-wrap">var y=</span><a href="/2024">2024</a><span class="title-event-wrap">;</span></h1><nav><ul><li><a href="/2024">[Calendar]</a></li><li><a href="/2024/support">[AoC++]</a></li><li><a href="/2024/sponsors">[Sponsors]</a></li><li><a href="/2024/leaderboard">[Leaderboard]</a></li><li><a href="/2024/stats">[Stats]</a></li></ul></nav></div></header>
+|]
+
+wrong :: T.Text
+wrong =
+  [trimming|
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+<meta charset="utf-8"/>
+<title>Advent of Code 2024</title>
+<link rel="stylesheet" type="text/css" href="/static/style.css?31"/>
+<link rel="stylesheet alternate" type="text/css" href="/static/highcontrast.css?1" title="High Contrast"/>
+<link rel="shortcut icon" href="/favicon.png"/>
+<script>window.addEventListener('click', function(e,s,r){if(e.target.nodeName==='CODE'&&e.detail===3){s=window.getSelection();s.removeAllRanges();r=document.createRange();r.selectNodeContents(e.target);s.addRange(r);}});</script>
+</head><!--
+|]
+
+removeLastNewline :: T.Text -> T.Text
+removeLastNewline text = fromMaybe text (T.stripSuffix "\n" text)
+
+spec :: Spec
+spec = describe "Stats" $ do
+  it "render success in json" $ do
+    renderSuccessOrError JsonRender (Right (Stats 10)) `shouldBe` exampleRender
+
+  it "render success in console" $ do
+    renderSuccessOrError ConsoleRender (Right (Stats 10)) `shouldBe` "stars:10"
+
+  it "render HTML parsing error" $ do
+    removeLastNewline (renderSuccessOrError ConsoleRender (parseIf200 200 wrong)) `shouldBe` parsingErrorExample
+
+  it "render HTTP status code error" $ do
+    renderSuccessOrError ConsoleRender (parseIf200 500 example) `shouldBe` "Unexpected HTTP status code response: 500"
+
+  it "parse valid html" $ do
+    parseIf200 200 example `shouldBe` Right (Stats 10)
+
+  it "parse wrong html" $ do
+    parseIf200 200 wrong `shouldSatisfy` isLeft
+
+  it "do not parse html if status is not 200" $ do
+    parseIf200 500 example `shouldBe` Left (Not200 500)
+
+  it "parses valid environment variables" $ do
+    let mockEnv = [("AOC_SESSION", "abc")]
+    Env.parsePure statsEnvVariablesParser mockEnv
+      `shouldBe` Right
+        ( StatsEnvVariables
+            { session = "abc"
+            }
+        )
+  it "parse valid html" $ do
+    parseIf200 200 example `shouldBe` Right (Stats 10)
+
+  it "parse wrong html" $ do
+    parseIf200 200 wrong `shouldSatisfy` isLeft
+
+  it "do not parse html if status is not 200" $ do
+    parseIf200 500 example `shouldBe` Left (Not200 500)
+
+  it "parses valid environment variables" $ do
+    let mockEnv = [("AOC_SESSION", "abc")]
+    Env.parsePure statsEnvVariablesParser mockEnv
+      `shouldBe` Right
+        ( StatsEnvVariables
+            { session = "abc"
+            }
+        )


### PR DESCRIPTION
Add a new command-line option to the aoc2024 CLI to retrieve stats (ie, number of stars in a given year) from https://adventofcode.com/

The CLI will have to support two types of output:
* human readable, as CLI output 
* json output to automatically override this file https://github.com/alessandrocandolini/advent-of-code2024/blob/main/.github/badges/completion.json that i use in the readme of the the project for the completion badge 

To authenticate, I will need a `AOC_SESSION` env variable with the session cookie. 
For HTML parsing, i was originally planning to use https://hackage.haskell.org/package/tagsoup, but 1. tagsoup uses `String` which is an inefficient choice for large docs like an HTML page 2. I already have megaparsec in scope, so it would be great to not have to add too many new dependencies 

Talking about 3rd party dependencies, in this PR i have to introduce a number of new dependencies: For making the request, I'm using `req`, for json serialisation `aeson`, for env variables parsing `envparse` which provides a nice applicative parsing API. 

<img width="525" alt="Screenshot 2024-12-08 at 22 21 22" src="https://github.com/user-attachments/assets/989a7a1b-e5ca-435a-b96f-a677af6b4814">

