### PR TITLE
Refactor operations on Mealy machine

### DIFF
--- a/test/Day3Spec.hs
+++ b/test/Day3Spec.hs
@@ -10,14 +10,14 @@ import Test.Hspec (Spec, describe, it, shouldBe)
 example1 :: T.Text
 example1 = "xmul(2,4)%&mul[3,7]!@^do_not_mul(5,5)+mul(32,64]then(mul(11,8)mul(8,5))"
 
-expected1 :: [Instruction]
-expected1 = [Mul 2 4, Mul 5 5, Mul 11 8, Mul 8 5]
+instructions1 :: [Instruction]
+instructions1 = [Mul 2 4, Mul 5 5, Mul 11 8, Mul 8 5]
 
 example2 :: T.Text
 example2 = "xmul(2,4)&mul[3,7]!^don't()_mul(5,5)+mul(32,64](mul(11,8)undo()?mul(8,5))"
 
-expected2 :: [Instruction]
-expected2 = [Mul 2 4, Dont, Mul 5 5, Mul 11 8, Do, Mul 8 5]
+instructions2 :: [Instruction]
+instructions2 = [Mul 2 4, Dont, Mul 5 5, Mul 11 8, Do, Mul 8 5]
 
 spec :: Spec
 spec = describe "Day 3" $ do
@@ -46,10 +46,18 @@ spec = describe "Day 3" $ do
     parseAll "amul(2,4)amul(3,5)a" `shouldBePretty` Right [Mul 2 4, Mul 3 5]
 
   it "can parse mul(decimal,decimal) in part1" $
-    parseAll example1 `shouldBePretty` Right expected1
+    parseAll example1 `shouldBePretty` Right instructions1
 
   it "can parse mul(decimal,decimal) in part2" $
-    parseAll example2 `shouldBePretty` Right expected2
+    parseAll example2 `shouldBePretty` Right instructions2
+
+  it "mapToggle hydrates the status of the toggle on each input" $
+    mapToggle fromInstruction instructions2
+      `shouldBe` [ (On, Multiply 2 4)
+                 , (Off, Multiply 5 5)
+                 , (Off, Multiply 11 8)
+                 , (On, Multiply 8 5)
+                 ]
 
   it "answer part 1" $
     logic example1 `shouldBePretty` Right (Answer 161 161)


### PR DESCRIPTION
Separare filtering from mapping. This **degrades performance** (as we are generating all the intermediate pairs, unused for the actual exercise), but provides a more compositional approach where we delay until the last minute the decision about the predicate used to filter by