### PR TITLE
day 6 part 1 using (abusing?) representable functors

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -19,6 +19,7 @@ dependencies:
 - data-fix
 - pretty
 - comonad
+- distributive
 - adjunctions
 - machines
 - algebraic-graphs
@@ -29,6 +30,7 @@ dependencies:
 - mtl
 - aeson
 - aeson-pretty
+- array
 
 default-extensions:
 - OverloadedStrings

--- a/src/Day6.hs
+++ b/src/Day6.hs
@@ -26,6 +26,7 @@ import Text.Megaparsec (Parsec, runParser, sepBy)
 import Text.Megaparsec.Char (char, newline)
 import Text.Megaparsec.Error (ParseErrorBundle)
 import Witherable (mapMaybe)
+import Prelude hiding (init)
 
 data Error
   = ParsingError ParserError
@@ -100,8 +101,8 @@ arrayToGrid defaultValue as = Grid g
 
 type LabMap = Store Grid Cell
 
-initialLabMap :: [[Cell]] -> Maybe LabMap
-initialLabMap cells = fmap (store initialGrid . fst) initialPatrol
+init :: [[Cell]] -> Maybe LabMap
+init cells = fmap (store initialGrid . fst) initialPatrol
  where
   cellsArray = listToArray cells
   initialGrid = ungrid (arrayToGrid OutOfbounds cellsArray)
@@ -192,7 +193,7 @@ countUnique = length . nub
 loadAndWalk :: [[Cell]] -> Either Error [(Position, Direction)]
 loadAndWalk cells =
   walk
-    <$> maybeToRight WalkerMissing (initialLabMap cells)
+    <$> maybeToRight WalkerMissing (init cells)
 
 -- parsing
 

--- a/src/Day6.hs
+++ b/src/Day6.hs
@@ -1,11 +1,207 @@
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE TypeFamilies #-}
+
 module Day6 where
+
+import Control.Applicative (many, (<|>))
+import Control.Comonad (extend, extract)
+import Control.Comonad.Representable.Store
+import Data.Array (Array, Ix, array, assocs, bounds, inRange, (!))
+import Data.Bifunctor (first)
+import Data.Distributive
+import Data.Either.Combinators (maybeToRight)
+import Data.Functor (($>))
+import Data.Functor.Rep
+import Data.List (nub, unfoldr)
+import Data.Maybe (fromMaybe)
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
+import Data.Void (Void)
+import Safe (headMay)
+import Text.Megaparsec (Parsec, runParser, sepBy)
+import Text.Megaparsec.Char (char, newline)
+import Text.Megaparsec.Error (ParseErrorBundle)
+import Witherable (mapMaybe)
+
+data Error
+  = ParsingError ParserError
+  | WalkerMissing
+  deriving (Eq, Show)
+
+newtype X = X Int deriving (Eq, Show, Num, Ord, Ix, Enum) via Int
+newtype Y = Y Int deriving (Eq, Show, Num, Ord, Ix, Enum) via Int
+type Position = (X, Y)
+
+data Cell
+  = OpenSpace
+  | Obstruction
+  | Guard Direction
+  | OutOfbounds
+  deriving (Eq, Show)
+
+data Direction
+  = North
+  | East
+  | South
+  | West
+  deriving (Eq, Show, Enum, Bounded)
+
+directionsClockwise :: Direction -> [Direction]
+directionsClockwise North = [North, East, South, West]
+directionsClockwise East = [East, South, West, North]
+directionsClockwise South = [South, West, North, East]
+directionsClockwise West = [West, North, East, South]
+
+moveForward :: Direction -> Position -> Position
+moveForward North (x, y) = (x, y - 1)
+moveForward South (x, y) = (x, y + 1)
+moveForward East (x, y) = (x + 1, y)
+moveForward West (x, y) = (x - 1, y)
+
+newtype Grid a = Grid {ungrid :: Position -> a} deriving (Functor)
+
+instance Distributive Grid where
+  distribute f = Grid $ \p -> fmap (\(Grid g) -> g p) f
+
+instance Representable Grid where
+  type Rep Grid = Position
+  index = ungrid
+  tabulate = Grid
+
+associatedList :: [[a]] -> [(Position, a)]
+associatedList = concatMap (\(j, row) -> zipWith (\i a -> ((i, j), a)) [0 ..] row) . zip [0 ..]
+
+dimensions :: [[a]] -> (X,Y)
+dimensions as = (numberOfColumns, numberOfRows) where
+  numberOfRows = Y (length as)
+  numberOfColumns = maybe 0 (X . length) (headMay as)
+
+-- will throw at runtime if grid is not rectangular
+-- array is also a strict function of the bounds and coordinates
+listToArray :: [[a]] -> Array Position a
+listToArray as = array corners (associatedList as)
+ where
+  (width, height) = dimensions as
+  corners = ((0, 0), (width - 1, height - 1))
+
+arrayToGrid :: a -> Array Position a -> Grid a
+arrayToGrid defaultValue as = Grid g
+ where
+  g p
+    | inRange (bounds as) p = as ! p
+    | otherwise = defaultValue
+
+initialLabMap :: [[Cell]] -> Maybe (LabMap, Position, Direction)
+initialLabMap cells = fmap (\p -> (store initialGrid (fst p), fst p, snd p)) initialHead
+ where
+  cellsArray = listToArray cells
+  initialGrid = ungrid (arrayToGrid OutOfbounds cellsArray)
+  initialHead = headMay (mapMaybe headPositionAndDirection (assocs cellsArray))
+  headPositionAndDirection :: (Position, Cell) -> Maybe (Position, Direction)
+  headPositionAndDirection (p, Guard d) = Just (p, d)
+  headPositionAndDirection _ = Nothing
+
+type LabMap = Store Grid Cell
+
+-- algebra
+
+currentGuardPosition :: LabMap -> Maybe (Position, Direction)
+currentGuardPosition = undefined
+
+checkAvailability :: LabMap -> Position -> Cell
+checkAvailability = undefined
+
+moveGuardToPosition :: LabMap -> Position -> LabMap
+moveGuardToPosition = undefined
+
+data Move = MoveTo Position Direction | GameOver
+
+nextMove :: LabMap -> Move
+nextMove game =
+  let
+    position :: Position
+    position = pos game
+    direction = fromMaybe South (currentDirection game) -- TODO
+    newPos :: Direction -> (Position, Direction, Cell)
+    newPos d =
+      let
+        candidate = moveForward d position
+       in
+        (candidate, d, peek candidate game)
+    candidates :: [(Position, Direction, Cell)]
+    candidates = fmap newPos (directionsClockwise direction)
+    res :: Move
+    res = case headMay candidates of
+      Just (_, _, OutOfbounds) -> GameOver
+      _ -> fromMaybe GameOver (headMay (mapMaybe available candidates))
+    available (p, d, OpenSpace) = Just (MoveTo p d)
+    available (p, d, Guard _) = Just (MoveTo p d) -- should we allow this
+    available _ = Nothing
+   in
+    res
+
+oneStep :: LabMap -> Maybe LabMap
+oneStep game = game'
+ where
+  current = pos game
+  move = nextMove game
+  game' :: Maybe LabMap
+  game' = case move of
+    (MoveTo p d) -> Just $ update game d current p
+    GameOver -> Nothing
+
+currentDirection :: LabMap -> Maybe Direction
+currentDirection game = case peek (pos game) game of
+  Guard d -> Just d
+  _ -> Nothing
+
+update :: LabMap -> Direction -> Position -> Position -> LabMap
+update game direction old new =
+  seek new $
+    extend (\s -> if pos s == new then Guard direction else if pos s == old then OpenSpace else extract s) game
+
+walk :: LabMap -> [(Position, Maybe Direction)]
+walk = unfoldr step
+ where
+  step :: LabMap -> Maybe ((Position, Maybe Direction), LabMap)
+  step = fmap (\g -> ((pos g, currentDirection g), g)) . oneStep
 
 program :: FilePath -> IO ()
 program = (=<<) print . fmap logic . T.readFile
 
-data Answer = Answer deriving (Eq, Show)
+data Answer = Answer Int deriving (Eq, Show)
 
-logic :: T.Text -> Answer
-logic = const Answer
+logic :: T.Text -> Either Error Answer
+logic = (=<<) answer . (first ParsingError . parse)
+
+answer :: [[Cell]] -> Either Error Answer
+answer = fmap Answer . part1
+
+part1 :: [[Cell]] -> Either Error Int
+part1 = fmap (countUnique . fmap fst) . loadAndWalk
+
+countUnique :: (Eq a) => [a] -> Int
+countUnique = length . nub
+
+loadAndWalk :: [[Cell]] -> Either Error [(Position, Maybe Direction)]
+loadAndWalk cells = do
+  (g, p, d) <- maybeToRight WalkerMissing (initialLabMap cells)
+  return $ (p, Just d) : walk g
+
+-- parsing
+
+type Parser = Parsec Void T.Text
+type ParserError = ParseErrorBundle T.Text Void
+
+cellParser :: Parser Cell
+cellParser =
+  (char '.' $> OpenSpace)
+    <|> (char '#' $> Obstruction)
+    <|> (char '^' $> Guard North)
+
+cellsParser :: Parser [[Cell]]
+cellsParser = sepBy (many cellParser) newline
+
+parse :: T.Text -> Either ParserError [[Cell]]
+parse = runParser cellsParser "input"

--- a/src/Day6.hs
+++ b/src/Day6.hs
@@ -72,8 +72,9 @@ instance Representable Grid where
 associatedList :: [[a]] -> [(Position, a)]
 associatedList = concatMap (\(j, row) -> zipWith (\i a -> ((i, j), a)) [0 ..] row) . zip [0 ..]
 
-dimensions :: [[a]] -> (X,Y)
-dimensions as = (numberOfColumns, numberOfRows) where
+dimensions :: [[a]] -> (X, Y)
+dimensions as = (numberOfColumns, numberOfRows)
+ where
   numberOfRows = Y (length as)
   numberOfColumns = maybe 0 (X . length) (headMay as)
 
@@ -106,14 +107,14 @@ type LabMap = Store Grid Cell
 
 -- algebra
 
-currentGuardPosition :: LabMap -> Maybe (Position, Direction)
-currentGuardPosition = undefined
+currentGuard :: LabMap -> Maybe (Position, Direction)
+currentGuard = undefined
 
 checkAvailability :: LabMap -> Position -> Cell
 checkAvailability = undefined
 
-moveGuardToPosition :: LabMap -> Position -> LabMap
-moveGuardToPosition = undefined
+moveGuard :: LabMap -> Position -> Direction -> LabMap
+moveGuard = undefined
 
 data Move = MoveTo Position Direction | GameOver
 

--- a/test/Day6Spec.hs
+++ b/test/Day6Spec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE OverloadedLists #-}
 
 module Day6Spec where
 
@@ -50,7 +51,7 @@ simple :: [[Cell]]
 simple =
   [ [OpenSpace, OpenSpace, OpenSpace, Obstruction, OpenSpace, OpenSpace]
   , [OpenSpace, OpenSpace, OpenSpace, OpenSpace, OpenSpace, Obstruction]
-  , [Obstruction, OpenSpace, OpenSpace, Guard North, OpenSpace, Obstruction]
+  , [Obstruction, OpenSpace, OpenSpace, Patrol North, OpenSpace, Obstruction]
   , [OpenSpace, Obstruction, OpenSpace, OpenSpace, OpenSpace, OpenSpace]
   , [OpenSpace, OpenSpace, OpenSpace, OpenSpace, Obstruction, OpenSpace]
   ]
@@ -76,7 +77,7 @@ simpleArray =
     , ((2, 4), OpenSpace)
     , ((3, 0), Obstruction)
     , ((3, 1), OpenSpace)
-    , ((3, 2), Guard North)
+    , ((3, 2), Patrol North)
     , ((3, 3), OpenSpace)
     , ((3, 4), OpenSpace)
     , ((4, 0), OpenSpace)
@@ -91,7 +92,7 @@ simpleArray =
     , ((5, 4), OpenSpace)
     ]
 
-parseLoadAndWalk :: T.Text -> Either Error [(Position, Maybe Direction)]
+parseLoadAndWalk :: T.Text -> Either Error [(Position, Direction)]
 parseLoadAndWalk text = (=<<) loadAndWalk (first ParsingError (parse text))
 
 spec :: Spec
@@ -105,59 +106,59 @@ spec = describe "Day 6" $ do
   it "buildArray" $ do
     listToArray simple `shouldBe` simpleArray -- array ((0, 0), (0, 0)) [((0, 0), OpenSpace)]
   it "walk simple example" $
-    loadAndWalk simple `shouldBe` Right [((3, 2), Just North), ((3, 1), Just North), ((4, 1), Just East), ((4, 2), Just South), ((4, 3), Just South), ((3, 3), Just West), ((2, 3), Just West), ((2, 2), Just North), ((2, 1), Just North), ((2, 0), Just North)]
+    loadAndWalk simple `shouldBe` Right [((3, 2), North), ((3, 1), North), ((4, 1), East), ((4, 2), South), ((4, 3), South), ((3, 3), West), ((2, 3), West), ((2, 2), North), ((2, 1), North), ((2, 0), North)]
 
   it "walk never hitting the edges" $
-    parseLoadAndWalk stuck `shouldBe` Right [((3, 1), Just North)]
+    parseLoadAndWalk stuck `shouldBe` Right [((3, 1), North)]
 
   it "walk" $
     parseLoadAndWalk input
       `shouldBe` Right
-        [ ((4, 6), Just North)
-        , ((4, 5), Just North)
-        , ((4, 4), Just North)
-        , ((4, 3), Just North)
-        , ((4, 2), Just North)
-        , ((4, 1), Just North)
-        , ((5, 1), Just East)
-        , ((6, 1), Just East)
-        , ((7, 1), Just East)
-        , ((8, 1), Just East)
-        , ((8, 2), Just South)
-        , ((8, 3), Just South)
-        , ((8, 4), Just South)
-        , ((8, 5), Just South)
-        , ((8, 6), Just South)
-        , ((7, 6), Just West)
-        , ((6, 6), Just West)
-        , ((5, 6), Just West)
-        , ((4, 6), Just West)
-        , ((3, 6), Just West)
-        , ((2, 6), Just West)
-        , ((2, 5), Just North)
-        , ((2, 4), Just North)
-        , ((3, 4), Just East)
-        , ((4, 4), Just East)
-        , ((5, 4), Just East)
-        , ((6, 4), Just East)
-        , ((6, 5), Just South)
-        , ((6, 6), Just South)
-        , ((6, 7), Just South)
-        , ((6, 8), Just South)
-        , ((5, 8), Just West)
-        , ((4, 8), Just West)
-        , ((3, 8), Just West)
-        , ((2, 8), Just West)
-        , ((1, 8), Just West)
-        , ((1, 7), Just North)
-        , ((2, 7), Just East)
-        , ((3, 7), Just East)
-        , ((4, 7), Just East)
-        , ((5, 7), Just East)
-        , ((6, 7), Just East)
-        , ((7, 7), Just East)
-        , ((7, 8), Just South)
-        , ((7, 9), Just South)
+        [ ((4, 6), North)
+        , ((4, 5), North)
+        , ((4, 4), North)
+        , ((4, 3), North)
+        , ((4, 2), North)
+        , ((4, 1), North)
+        , ((5, 1), East)
+        , ((6, 1), East)
+        , ((7, 1), East)
+        , ((8, 1), East)
+        , ((8, 2), South)
+        , ((8, 3), South)
+        , ((8, 4), South)
+        , ((8, 5), South)
+        , ((8, 6), South)
+        , ((7, 6), West)
+        , ((6, 6), West)
+        , ((5, 6), West)
+        , ((4, 6), West)
+        , ((3, 6), West)
+        , ((2, 6), West)
+        , ((2, 5), North)
+        , ((2, 4), North)
+        , ((3, 4), East)
+        , ((4, 4), East)
+        , ((5, 4), East)
+        , ((6, 4), East)
+        , ((6, 5), South)
+        , ((6, 6), South)
+        , ((6, 7), South)
+        , ((6, 8), South)
+        , ((5, 8), West)
+        , ((4, 8), West)
+        , ((3, 8), West)
+        , ((2, 8), West)
+        , ((1, 8), West)
+        , ((1, 7), North)
+        , ((2, 7), East)
+        , ((3, 7), East)
+        , ((4, 7), East)
+        , ((5, 7), East)
+        , ((6, 7), East)
+        , ((7, 7), East)
+        , ((7, 8), South)
+        , ((7, 9), South)
         ]
 
   it "logic" $

--- a/test/Day6Spec.hs
+++ b/test/Day6Spec.hs
@@ -1,21 +1,164 @@
+{-# LANGUAGE QuasiQuotes #-}
+
 module Day6Spec where
 
-import Day6
-import Test.Hspec
-import Test.Hspec.QuickCheck
-import Test.QuickCheck
+import Data.Array (Array, array)
+import Data.Bifunctor (first)
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
+import Day6
+import NeatInterpolation (trimming)
+import SpecUtils (shouldBePretty)
+import Test.Hspec (Spec, describe, it, shouldBe)
+import Test.Hspec.QuickCheck
+import Test.QuickCheck
+
+input :: T.Text
+input =
+  [trimming|
+....#.....
+.........#
+..........
+..#.......
+.......#..
+..........
+.#..^.....
+........#.
+#.........
+......#...
+|]
+
+stuck :: T.Text
+stuck =
+  [trimming|
+...#..
+#.#^##
+...##.
+|]
+
+simpleInput :: T.Text
+simpleInput =
+  [trimming|
+...#..
+.....#
+#..^.#
+.#....
+....#.
+|]
+
+simple :: [[Cell]]
+simple =
+  [ [OpenSpace, OpenSpace, OpenSpace, Obstruction, OpenSpace, OpenSpace]
+  , [OpenSpace, OpenSpace, OpenSpace, OpenSpace, OpenSpace, Obstruction]
+  , [Obstruction, OpenSpace, OpenSpace, Guard North, OpenSpace, Obstruction]
+  , [OpenSpace, Obstruction, OpenSpace, OpenSpace, OpenSpace, OpenSpace]
+  , [OpenSpace, OpenSpace, OpenSpace, OpenSpace, Obstruction, OpenSpace]
+  ]
+
+simpleArray :: Array Position Cell
+simpleArray =
+  array
+    ((0, 0), (5, 4))
+    [ ((0, 0), OpenSpace)
+    , ((0, 1), OpenSpace)
+    , ((0, 2), Obstruction)
+    , ((0, 3), OpenSpace)
+    , ((0, 4), OpenSpace)
+    , ((1, 0), OpenSpace)
+    , ((1, 1), OpenSpace)
+    , ((1, 2), OpenSpace)
+    , ((1, 3), Obstruction)
+    , ((1, 4), OpenSpace)
+    , ((2, 0), OpenSpace)
+    , ((2, 1), OpenSpace)
+    , ((2, 2), OpenSpace)
+    , ((2, 3), OpenSpace)
+    , ((2, 4), OpenSpace)
+    , ((3, 0), Obstruction)
+    , ((3, 1), OpenSpace)
+    , ((3, 2), Guard North)
+    , ((3, 3), OpenSpace)
+    , ((3, 4), OpenSpace)
+    , ((4, 0), OpenSpace)
+    , ((4, 1), OpenSpace)
+    , ((4, 2), OpenSpace)
+    , ((4, 3), OpenSpace)
+    , ((4, 4), Obstruction)
+    , ((5, 0), OpenSpace)
+    , ((5, 1), Obstruction)
+    , ((5, 2), Obstruction)
+    , ((5, 3), OpenSpace)
+    , ((5, 4), OpenSpace)
+    ]
+
+parseLoadAndWalk :: T.Text -> Either Error [(Position, Maybe Direction)]
+parseLoadAndWalk text = (=<<) loadAndWalk (first ParsingError (parse text))
 
 spec :: Spec
-spec = describe "Day 5" $ do
-  it ""
-    $ 1
-    `shouldBe` 1
+spec = describe "Day 6" $ do
+  it "all directions clockwise" $
+    directionsClockwise South `shouldBe` [South, West, North, East]
 
-  prop ""
-    $ \l -> reverse (reverse l) == (l :: [Int])
+  it "parse successfully a simple input" $
+    parse simpleInput `shouldBePretty` Right simple
 
-  xit "solve the puzzle" $ do
-     input <- T.readFile "resources/input6"
-     logic input `shouldBe` Answer
+  it "buildArray" $ do
+    listToArray simple `shouldBe` simpleArray -- array ((0, 0), (0, 0)) [((0, 0), OpenSpace)]
+  it "walk simple example" $
+    loadAndWalk simple `shouldBe` Right [((3, 2), Just North), ((3, 1), Just North), ((4, 1), Just East), ((4, 2), Just South), ((4, 3), Just South), ((3, 3), Just West), ((2, 3), Just West), ((2, 2), Just North), ((2, 1), Just North), ((2, 0), Just North)]
+
+  it "walk never hitting the edges" $
+    parseLoadAndWalk stuck `shouldBe` Right [((3, 1), Just North)]
+
+  it "walk" $
+    parseLoadAndWalk input
+      `shouldBe` Right
+        [ ((4, 6), Just North)
+        , ((4, 5), Just North)
+        , ((4, 4), Just North)
+        , ((4, 3), Just North)
+        , ((4, 2), Just North)
+        , ((4, 1), Just North)
+        , ((5, 1), Just East)
+        , ((6, 1), Just East)
+        , ((7, 1), Just East)
+        , ((8, 1), Just East)
+        , ((8, 2), Just South)
+        , ((8, 3), Just South)
+        , ((8, 4), Just South)
+        , ((8, 5), Just South)
+        , ((8, 6), Just South)
+        , ((7, 6), Just West)
+        , ((6, 6), Just West)
+        , ((5, 6), Just West)
+        , ((4, 6), Just West)
+        , ((3, 6), Just West)
+        , ((2, 6), Just West)
+        , ((2, 5), Just North)
+        , ((2, 4), Just North)
+        , ((3, 4), Just East)
+        , ((4, 4), Just East)
+        , ((5, 4), Just East)
+        , ((6, 4), Just East)
+        , ((6, 5), Just South)
+        , ((6, 6), Just South)
+        , ((6, 7), Just South)
+        , ((6, 8), Just South)
+        , ((5, 8), Just West)
+        , ((4, 8), Just West)
+        , ((3, 8), Just West)
+        , ((2, 8), Just West)
+        , ((1, 8), Just West)
+        , ((1, 7), Just North)
+        , ((2, 7), Just East)
+        , ((3, 7), Just East)
+        , ((4, 7), Just East)
+        , ((5, 7), Just East)
+        , ((6, 7), Just East)
+        , ((7, 7), Just East)
+        , ((7, 8), Just South)
+        , ((7, 9), Just South)
+        ]
+
+  it "logic" $
+    logic input `shouldBe` Right (Answer 41)


### PR DESCRIPTION
At its core, day 6 part 1 is a straightforward `unfoldr`. Given the input `[[Cell]]`, the starting walker position, and the initial direction of travel, we can inductively generate the next candidate walker position and direction, step by step, by applying the given rules. The unfold terminates if we either exhaust all possible directions or explicitly reach the grid's edges. The only think that we need is to build some indexable data structure (Map or Array) adn everything can be implemented efficiently with no need for other abstractions. I should probably add a simpler implementation here for comparison. 

In this PR however I've tried a different approach to keep track of the state: the unfoldr is formulated in term of a `Store Comonad` over the `Representable` instance for the distributive functor `data Grid a = Grid ( Position -> a)`, a commonly used abstraction to perform 2D grids manipulations. 

Now, using advanced techniques like this one can sometimes unlock shorter, elegant, concise, and more performant ways to solve problems. Is this one of those cases though? I have doubts! few notes are in order

On the positive side, the `Store comonad` gives us a standard algebra of operations to access certain aspects of the grid. Specifically, 
* `peek` to get current focus (ie, get the current position of the walker) 
* check the next move based on presence of edges or obstructions on the lab map 
* `seek` and the comonadic `extend` and `extract` to move the focus point int the lab map. 

And it does all of that with limited performance impact. on that front, please consider that the store comonad provides an automatically memoised access, and together with the fact that the `Grid a` representable functor is backed by a (boxed) `Array Position a` (which provides O(1) lookup for any position, even on first access) the overall performance is decent. Surely it can be improved further, but currently on my machine it executes in under 300ms on the actual puzzle input:
```
 time aoc2024 run -d 6 -f inputs/day6
Right (Answer 4758)

real    0m0.334s
user    0m0.265s
sys     0m0.041s
```
I plan to implement explicit benchmarks in a future PR

Despite these positives, there are several aspects of the current implementation that I’m not entirely happy about. In particular, i had to hammer the data modelling and signatures of some functions, to accommodate the needs of `Representable` and `Store comonad`. Specifically, 

**Handling Finite Grids**: Working with finite grids whose size is only determined at runtime introduces complications when using Representable. Ideally, we would like `Position -> a` to be a total function, but this isn’t feasible for finite grids (recall: `Maybe` is not `Representable`). In this implementation, I’ve handled this by enriching the `Cell` type with an additional `Edge` case, used as the default for out-of-bounds positions. While this approach works for my use case, it does pollute the `Cell` type with unnecessary cases, limiting its ability to accommodate future requirements.

**Direction Lookup**: Retrieving the previous direction is less elegant than I’d like. While the current position is easily accessible in the Store comonad using `pos`, determining the direction requires parsing the cell content at that position.
It can go wrong if we mistakenly move the focus point to the wrong location where there is no guard. We can’t easily enforce this guarantee at the type level. As a result, we must "parse" the value again, which introduces unnecessary complexity and results in a spurious `Maybe Direction`, forcing "accidental error handling" which does not steam from the business logic itself and just from the encoding, and which is indeed a sign of bad/imprecise modelling (would always be preferrable to make such situations impossible by construction)

This latter issue likely stems from conflating the grid's representation with the walker's state in the same entity. While this alignment is 1:1 with the underlying puzzle input, it might make sense to separate Grid and Walker in the business logic for better clarity and composability.

One thing that instead seems genuine complexity of this exercise is the amount of unhappy paths and error handling that we need to ensure it's in place. The initial grid might be not rectangular, nto containing the guard, containing multiple guards, etc