### PR TITLE
Add support for stdio

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,33 @@ To run a version of **ghci** compatible with the resolver
 stack ghci
 ```
 For more information, refer to the `stack` official docs.
+
+
+## Available commands
+
+Thanks to [optparse-applicative](https://hackage.haskell.org/package/optparse-applicative), the CLI automatically generates documentation from code. It's recommended to use the generated helper to explore all the options. However, a summary is provided here of the most relevant options. 
+
+
+### Run solutions
+
+From file:
+```
+aoc2024 run -d 1 -f inputs/day1
+```
+
+From standard input: 
+```
+aoc2024 run -d 1  --with-input < inputs/day1 
+```
+or 
+```
+cat input/day1 | aoc2024 run -d 1 --with-input 
+```
+
+### Retrieve stats
+```
+export AOC_SESSION=<insert the cookie value> 
+aoc2024 stats 
+aoc2024 stats -y 2024
+aoc2024 stats -y 2024 --json
+```

--- a/src/App.hs
+++ b/src/App.hs
@@ -6,19 +6,12 @@ import Args (
   GenerateArgs (GenerateArgs),
   StatsArgs (StatsArgs),
   parseArgs,
+  readInput,
  )
 import CodeGenerator (program)
-import Day1 (program)
-import Day10 (program)
-import Day2 (program)
-import Day3 (program)
-import Day4 (program)
-import Day5 (program)
-import Day6 (program)
-import Day7 (program)
-import Day8 (program)
-import Day9 (program)
+import qualified Data.Text as T
 import Options.Applicative (handleParseResult)
+import Solutions (solutions)
 import Stats (program)
 import System.Environment (getArgs)
 
@@ -27,16 +20,16 @@ program =
   getArgs >>= (handleParseResult . parseArgs) >>= program'
 
 program' :: Command -> IO ()
-program' (Run (Args 1 f)) = Day1.program f
-program' (Run (Args 2 f)) = Day2.program f
-program' (Run (Args 3 f)) = Day3.program f
-program' (Run (Args 4 f)) = Day4.program f
-program' (Run (Args 5 f)) = Day5.program f
-program' (Run (Args 6 f)) = Day6.program f
-program' (Run (Args 7 f)) = Day7.program f
-program' (Run (Args 8 f)) = Day8.program f
-program' (Run (Args 9 f)) = Day9.program f
-program' (Run (Args 10 f)) = Day10.program f
-program' (Run (Args _ _)) = putStrLn "day not found"
+program' (Run (Args n input)) = readInput input >>= runSolution n
 program' (Generate (GenerateArgs d)) = CodeGenerator.program d
 program' (GetStats (StatsArgs year export)) = Stats.program year export
+
+runSolution :: Int -> T.Text -> IO ()
+runSolution n input = case solution n of
+  Just s -> s input
+  Nothing -> putStrLn "day not found"
+
+solution :: Int -> Maybe (T.Text -> IO ())
+solution n
+  | n >= 1 && n <= length solutions = Just (solutions !! (n - 1))
+  | otherwise = Nothing

--- a/src/Args.hs
+++ b/src/Args.hs
@@ -1,5 +1,7 @@
 module Args where
 
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
 import Options.Applicative
 
 data Command
@@ -10,9 +12,32 @@ data Command
 
 data Args = Args
   { day :: Int
-  , input :: FilePath
+  , input :: DayInput
   }
   deriving (Eq, Show)
+
+data DayInput = FromFile FilePath | FromStdInput deriving (Eq, Show)
+
+readInput :: DayInput -> IO T.Text
+readInput (FromFile f) = T.readFile f
+readInput FromStdInput = T.getContents
+
+dayInputParser :: Parser DayInput
+dayInputParser = fromFileParser <|> fromStdInputParser
+ where
+  fromFileParser =
+    FromFile
+      <$> strOption
+        ( long "filename"
+            <> short 'f'
+            <> help "Read input from the specified file"
+        )
+  fromStdInputParser =
+    flag'
+      FromStdInput
+      ( long "with-input"
+          <> help "Read input from standard input"
+      )
 
 newtype GenerateArgs = GenerateArgs Int deriving (Eq, Show)
 data StatsRender = ConsoleRender | JsonRender deriving (Eq, Show)
@@ -27,11 +52,7 @@ argsParser =
           <> short 'd'
           <> help "day"
       )
-    <*> strOption
-      ( long "filename"
-          <> short 'f'
-          <> help "filename"
-      )
+    <*> dayInputParser
 
 generateArgsParser :: Parser GenerateArgs
 generateArgsParser =

--- a/src/Day1.hs
+++ b/src/Day1.hs
@@ -6,7 +6,6 @@ import Data.Hashable (Hashable)
 import Data.List (foldl', sort)
 import Data.Semigroup (Sum (..))
 import qualified Data.Text as T
-import qualified Data.Text.IO as T
 import Data.Tuple (swap)
 import Data.Void (Void)
 import Text.Megaparsec (Parsec, runParser, sepBy)
@@ -14,8 +13,8 @@ import Text.Megaparsec.Char (newline, space)
 import Text.Megaparsec.Char.Lexer (decimal)
 import Text.Megaparsec.Error (ParseErrorBundle)
 
-program :: FilePath -> IO ()
-program = (=<<) print . fmap logic . T.readFile
+program :: T.Text -> IO ()
+program = print . logic
 
 data Answer = Answer Int Int deriving (Eq, Show)
 

--- a/src/Day2.hs
+++ b/src/Day2.hs
@@ -6,15 +6,14 @@ import Control.Applicative (many)
 import Data.List (group, inits, tails)
 import qualified Data.List.NonEmpty as N
 import qualified Data.Text as T
-import qualified Data.Text.IO as T
 import Data.Void (Void)
 import Text.Megaparsec (Parsec, optional, runParser)
 import Text.Megaparsec.Char (eol, space)
 import Text.Megaparsec.Char.Lexer (decimal)
 import Text.Megaparsec.Error (ParseErrorBundle)
 
-program :: FilePath -> IO ()
-program = (=<<) print . fmap logic . T.readFile
+program :: T.Text -> IO ()
+program = print . logic
 
 data Answer = Answer Int Int deriving (Eq, Show)
 
@@ -57,7 +56,7 @@ distance = (abs .) . (-)
 pairwiseDistances :: (Num a) => [a] -> [a]
 pairwiseDistances as = uncurry distance <$> zip as (tail as)
 
-pairwiseDistanceAlwaysLessThan :: (Ord a, Num a) =>a -> [a] -> Bool
+pairwiseDistanceAlwaysLessThan :: (Ord a, Num a) => a -> [a] -> Bool
 pairwiseDistanceAlwaysLessThan threshold = maybe True ((<= threshold) . maximum) . N.nonEmpty . pairwiseDistances
 
 isSafe1 :: (Ord a, Num a) => [a] -> Bool

--- a/src/Day3.hs
+++ b/src/Day3.hs
@@ -5,7 +5,6 @@ import Data.Machine (Mealy)
 import qualified Data.Machine as M
 import Data.Semigroup (Sum (..))
 import qualified Data.Text as T
-import qualified Data.Text.IO as T
 import Data.Void (Void)
 import Text.Megaparsec (MonadParsec (try), Parsec, anySingle, runParser, skipManyTill)
 import Text.Megaparsec.Char (char, string)
@@ -13,8 +12,8 @@ import Text.Megaparsec.Char.Lexer (decimal)
 import Text.Megaparsec.Error (ParseErrorBundle)
 import Witherable (catMaybes, mapMaybe)
 
-program :: FilePath -> IO ()
-program = (=<<) print . fmap logic . T.readFile
+program :: T.Text -> IO ()
+program = print . logic
 
 data Answer = Answer Int Int deriving (Eq, Show)
 

--- a/src/Day4.hs
+++ b/src/Day4.hs
@@ -2,11 +2,10 @@ module Day4 where
 
 import Data.List (tails, transpose)
 import qualified Data.Text as T
-import qualified Data.Text.IO as T
 import Witherable (mapMaybe)
 
-program :: FilePath -> IO ()
-program = (=<<) print . fmap logic . T.readFile
+program :: T.Text -> IO ()
+program = print . logic
 
 data Answer = Answer Int Int deriving (Eq, Show)
 

--- a/src/Day5.hs
+++ b/src/Day5.hs
@@ -14,7 +14,6 @@ import qualified Data.Map.Strict as M
 import Data.Semigroup (Sum (..))
 import qualified Data.Set as S
 import qualified Data.Text as T
-import qualified Data.Text.IO as T
 import Data.Void (Void)
 import Safe (headMay)
 import System.Console.ANSI (Color (..))
@@ -22,11 +21,11 @@ import Text.Megaparsec (Parsec, endBy, runParser, sepBy)
 import Text.Megaparsec.Char (char, newline)
 import Text.Megaparsec.Char.Lexer (decimal)
 import Text.Megaparsec.Error (ParseErrorBundle)
-import Witherable (catMaybes, mapMaybe)
 import Utils (colorText)
+import Witherable (catMaybes, mapMaybe)
 
-program :: FilePath -> IO ()
-program = (=<<) print . fmap logic . T.readFile
+program :: T.Text -> IO ()
+program = print . logic
 
 data GraphResolutionError a = GraphResolutionError (Cycle a) [(a, a)] [a] deriving (Eq)
 

--- a/src/Day6.hs
+++ b/src/Day6.hs
@@ -19,7 +19,6 @@ import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as N
 import Data.Maybe (fromMaybe)
 import qualified Data.Text as T
-import qualified Data.Text.IO as T
 import Data.Void (Void)
 import Safe (headMay)
 import Text.Megaparsec (Parsec, runParser, sepBy)
@@ -173,8 +172,8 @@ walk m = unfoldr step (Just m)
     let nextMap = oneStep next position direction
     Just ((position, direction), nextMap)
 
-program :: FilePath -> IO ()
-program = (=<<) print . fmap logic . T.readFile
+program :: T.Text -> IO ()
+program = print . logic
 
 data Answer = Answer Int deriving (Eq, Show)
 

--- a/src/Solutions.hs
+++ b/src/Solutions.hs
@@ -1,0 +1,19 @@
+module Solutions where
+
+import qualified Data.Text as T
+import Day1 (program)
+import Day2 (program)
+import Day3 (program)
+import Day4 (program)
+import Day5 (program)
+import Day6 (program)
+
+solutions :: [T.Text -> IO ()]
+solutions =
+  [ Day1.program
+  , Day2.program
+  , Day3.program
+  , Day4.program
+  , Day5.program
+  , Day6.program
+  ]

--- a/test/ArgsSpec.hs
+++ b/test/ArgsSpec.hs
@@ -14,8 +14,11 @@ parseArgsMaybe = transform . parseArgs
 
 spec :: Spec
 spec = describe "Args parser" $ do
-  it "is able to parse a valid command to run the solution" $
-    parseArgsMaybe ["run", "-d", "1", "-f", "file"] `shouldBe` Right (Run (Args 1 "file"))
+  it "is able to parse a valid command to run the solution from file" $
+    parseArgsMaybe ["run", "-d", "1", "-f", "file"] `shouldBe` Right (Run (Args 1 (FromFile "file")))
+
+  it "is able to parse a valid command to run the solution from standard input" $
+    parseArgsMaybe ["run", "-d", "1", "--with-input"] `shouldBe` Right (Run (Args 1 FromStdInput))
 
   it "is able to parse a valid command to generate the scaffolding for a new day" $
     parseArgsMaybe ["generate", "-d", "1"] `shouldBe` Right (Generate (GenerateArgs 1))


### PR DESCRIPTION
Added option to get input puzzle directly from standard input. Show examples in readme using `cat` , but the main usecase I have in mind is to use `pbpaste`  (in macos)
```
 pbpaste | aoc2024 run -d 6 --with-input
```